### PR TITLE
Add a comment about TextureFormat for PNG

### DIFF
--- a/docs/showcase/windowless/README.md
+++ b/docs/showcase/windowless/README.md
@@ -19,7 +19,7 @@ let (device, queue) = adapter.request_device(&Default::default()).await;
 
 ## A triangle without a window
 
-Now we've talked about not needing to see what the gpu is doing, but we do need to see the results at some point. If we look back to talking about the [swap chain](/beginner/tutorial2-swapchain/#render) we see that we use `swap_chain.get_next_texture()` to grab a texture to draw to. We'll skip that step by creating the texture ourselves.
+Now we've talked about not needing to see what the gpu is doing, but we do need to see the results at some point. If we look back to talking about the [swap chain](/beginner/tutorial2-swapchain/#render) we see that we use `swap_chain.get_next_texture()` to grab a texture to draw to. We'll skip that step by creating the texture ourselves. One thing to note here is we need to specify `wgpu::TextureFormat::Rgba8UnormSrgb` to `format` instead of `wgpu::TextureFormat::Bgra8UnormSrgb` since PNG uses RGBA, not BGRA.
 
 ```rust
 let texture_size = 256u32;


### PR DESCRIPTION
It might be obvious to the ordinary users, but I I needed some time to figure out the difference, so I think it's nice to have some short comment about the TextureFormat for PNG. Does this make sense...?