### PR TITLE
Use std::iter::once for encoder queue submission

### DIFF
--- a/code/beginner/tutorial2-swapchain/src/challenge.rs
+++ b/code/beginner/tutorial2-swapchain/src/challenge.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -117,7 +119,7 @@ impl State {
             });
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial2-swapchain/src/main.rs
+++ b/code/beginner/tutorial2-swapchain/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -104,7 +106,7 @@ impl State {
         }
 
         // submit will accept anything that implements IntoIter
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial3-pipeline/src/challenge.rs
+++ b/code/beginner/tutorial3-pipeline/src/challenge.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -232,7 +234,7 @@ impl State {
             render_pass.draw(0..3, 0..1);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial3-pipeline/src/main.rs
+++ b/code/beginner/tutorial3-pipeline/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -164,7 +166,7 @@ impl State {
             render_pass.draw(0..3, 0..1);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial4-buffer/src/challenge.rs
+++ b/code/beginner/tutorial4-buffer/src/challenge.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -313,7 +315,7 @@ impl State {
             render_pass.draw_indexed(0..data.2, 0, 0..1);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial4-buffer/src/main.rs
+++ b/code/beginner/tutorial4-buffer/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -234,7 +236,7 @@ impl State {
             render_pass.draw_indexed(0..self.num_indices, 0, 0..1);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial5-textures/src/challenge.rs
+++ b/code/beginner/tutorial5-textures/src/challenge.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -343,7 +345,7 @@ impl State {
             render_pass.draw_indexed(0..self.num_indices, 0, 0..1);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial5-textures/src/main.rs
+++ b/code/beginner/tutorial5-textures/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -294,7 +296,7 @@ impl State {
             render_pass.draw_indexed(0..self.num_indices, 0, 0..1);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial6-uniforms/src/challenge.rs
+++ b/code/beginner/tutorial6-uniforms/src/challenge.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -520,7 +522,7 @@ impl State {
             render_pass.draw_indexed(0..self.num_indices, 0, 0..1);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial6-uniforms/src/main.rs
+++ b/code/beginner/tutorial6-uniforms/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -505,7 +507,7 @@ impl State {
             render_pass.draw_indexed(0..self.num_indices, 0, 0..1);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial7-instancing/src/challenge.rs
+++ b/code/beginner/tutorial7-instancing/src/challenge.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use cgmath::prelude::*;
 use winit::{
     event::*,
@@ -619,7 +621,7 @@ impl State {
             render_pass.draw_indexed(0..self.num_indices, 0, 0..self.instances.len() as u32);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial7-instancing/src/main.rs
+++ b/code/beginner/tutorial7-instancing/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use cgmath::prelude::*;
 use winit::{
     event::*,
@@ -573,7 +575,7 @@ impl State {
             render_pass.draw_indexed(0..self.num_indices, 0, 0..self.instances.len() as _);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial8-depth/src/challenge.rs
+++ b/code/beginner/tutorial8-depth/src/challenge.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use winit::{
     event::*,
     event_loop::{EventLoop, ControlFlow},
@@ -785,7 +787,7 @@ impl State {
 
         self.depth_pass.render(&frame, &mut encoder);
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial8-depth/src/main.rs
+++ b/code/beginner/tutorial8-depth/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use cgmath::prelude::*;
 use winit::{
     event::*,
@@ -597,7 +599,7 @@ impl State {
             render_pass.draw_indexed(0..self.num_indices, 0, 0..self.instances.len() as u32);
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/beginner/tutorial9-models/src/main.rs
+++ b/code/beginner/tutorial9-models/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use cgmath::prelude::*;
 use winit::{
     event::*,
@@ -515,7 +517,7 @@ impl State {
             );
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/intermediate/tutorial10-lighting/src/main.rs
+++ b/code/intermediate/tutorial10-lighting/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use cgmath::prelude::*;
 use winit::{
     event::*,
@@ -631,7 +633,7 @@ impl State {
             );
         }
 
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/intermediate/tutorial11-normals/src/main.rs
+++ b/code/intermediate/tutorial11-normals/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use cgmath::prelude::*;
 use winit::{
     event::*,
@@ -658,7 +660,7 @@ impl State {
                 &self.light_bind_group,
             );
         }
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/intermediate/tutorial12-camera/src/main.rs
+++ b/code/intermediate/tutorial12-camera/src/main.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use cgmath::prelude::*;
 use winit::{
     dpi::PhysicalPosition,
@@ -579,7 +581,7 @@ impl State {
                 &self.light_bind_group,
             );
         }
-        self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(iter::once(encoder.finish()));
     }
 }
 

--- a/code/showcase/gifs/src/main.rs
+++ b/code/showcase/gifs/src/main.rs
@@ -1,7 +1,7 @@
 extern crate framework;
 
 use anyhow::*;
-use std::mem;
+use std::{iter, mem};
 
 async fn run() {
     let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
@@ -119,7 +119,7 @@ async fn run() {
             render_target.desc.size
         );
 
-        queue.submit(Some(encoder.finish()));
+        queue.submit(iter::once(encoder.finish()));
         
         // Create the map request
         let buffer_slice = output_buffer.slice(..);

--- a/code/showcase/pong/src/render/mod.rs
+++ b/code/showcase/pong/src/render/mod.rs
@@ -1,5 +1,7 @@
 mod buffer;
 
+use std::iter;
+
 use winit::window::{Window};
 use winit::monitor::{VideoMode};
 use wgpu_glyph::{ab_glyph, Section, Text};
@@ -189,7 +191,7 @@ impl Render {
                 ).unwrap();
         
                 self.staging_belt.finish();
-                self.queue.submit(Some(encoder.finish()));
+                self.queue.submit(iter::once(encoder.finish()));
             }
             Err(wgpu::SwapChainError::Outdated) => {
                 self.swap_chain = self.device.create_swap_chain(&self.surface, &self.sc_desc);

--- a/docs/beginner/tutorial2-swapchain/README.md
+++ b/docs/beginner/tutorial2-swapchain/README.md
@@ -300,7 +300,7 @@ Now we can actually get to clearing the screen (long time coming). We need to us
     }
 
     // submit will accept anything that implements IntoIter
-    self.queue.submit(Some(encoder.finish()));
+    self.queue.submit(std::iter::once(encoder.finish()));
 }
 ```
 

--- a/docs/showcase/gifs/README.md
+++ b/docs/showcase/gifs/README.md
@@ -140,7 +140,7 @@ for c in &colors {
         render_target.desc.size
     );
 
-    queue.submit(Some(encoder.finish()));
+    queue.submit(std::iter::once(encoder.finish()));
     
     // Create the map request
     let buffer_slice = output_buffer.slice(..);


### PR DESCRIPTION
`std::iter::once` is more idiomatic for passing single-value iterators than `Some(value)`, and it's even intended for this case
according to [the docs](https://doc.rust-lang.org/std/iter/fn.once.html).