### PR TITLE
Fix typos and update Beginner tutorials 2, 3

### DIFF
--- a/docs/beginner/tutorial2-swapchain/README.md
+++ b/docs/beginner/tutorial2-swapchain/README.md
@@ -17,23 +17,23 @@ struct State {
 impl State {
     // Creating some of the wgpu types requires async code
     async fn new(window: &Window) -> Self {
-        unimplemented!()
+        todo!()
     }
 
     fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
-        unimplemented!()
+        todo!()
     }
 
     fn input(&mut self, event: &WindowEvent) -> bool {
-        unimplemented!()
+        todo!()
     }
 
     fn update(&mut self) {
-        unimplemented!()
+        todo!()
     }
 
     fn render(&mut self) {
-        unimplemented!()
+        todo!()
     }
 }
 ```
@@ -249,7 +249,7 @@ We don't have anything to update yet, so leave the method empty.
 
 ```rust
 fn update(&mut self) {
-    // remove `unimplemented!()`
+    // remove `todo!()`
 }
 ```
 
@@ -367,11 +367,11 @@ wgpu::RenderPassColorAttachmentDescriptor {
 }
 ```
 
-The `RenderPassColorAttachmentDescriptor` has the `attachment` field which informs `wgpu` what texture to save the colors to. In this case we specify `frame.view` that we created using `swap_chain.get_next_texture()`. This means that any colors we draw to this attachment will get drawn to the screen.
+The `RenderPassColorAttachmentDescriptor` has the `attachment` field which informs `wgpu` what texture to save the colors to. In this case we specify `frame.view` that we created using `swap_chain.get_current_frame()`. This means that any colors we draw to this attachment will get drawn to the screen.
 
-This is the texture that will received the resolved output. This will be the same as `attachment` unless multisampling is enabled. We don't need to specify this, so we leave it as `None`.
+This is the texture that will receive the resolved output. This will be the same as `attachment` unless multisampling is enabled. We don't need to specify this, so we leave it as `None`.
 
-The `obs` field takes an `wpgu::Operations` object. This tells wgpu what to do with the colors on the screen (specified by `frame.view`). The `load` field tells wgpu how to handle colors store from the previous frame. Currently we are clearing the screen with a bluish color.
+The `ops` field takes a `wpgu::Operations` object. This tells wgpu what to do with the colors on the screen (specified by `frame.view`). The `load` field tells wgpu how to handle colors stored from the previous frame. Currently we are clearing the screen with a bluish color.
 
 <div class="note">
 
@@ -383,6 +383,6 @@ It's not uncommon to not clear the screen if the streen is going to be completel
 
 ## Challenge
 
-Modify the `input()` method to capture mouse events, and update the clear color using that. *Hint: you'll probably need to use `WindowEvent::CursorMoved`*
+Modify the `input()` method to capture mouse events, and update the clear color using that. *Hint: you'll probably need to use `WindowEvent::CursorMoved`*.
 
 <AutoGithubLink/>

--- a/docs/beginner/tutorial9-models/README.md
+++ b/docs/beginner/tutorial9-models/README.md
@@ -20,7 +20,7 @@ pub struct ModelVertex {
 
 impl Vertex for ModelVertex {
     fn desc<'a>() -> wgpu::VertexBufferDescriptor<'a> {
-        unimplemented!();
+        todo!();
     }
 }
 ```
@@ -469,7 +469,7 @@ The code in `main.rs` will change accordingly.
 
 ```rust
 render_pass.set_pipeline(&self.render_pipeline);
-render_pass.draw_model_instanced(&self.obj_model, 0..self.instances.len() as u32, &self.uniform_bind_group); 
+render_pass.draw_model_instanced(&self.obj_model, 0..self.instances.len() as u32, &self.uniform_bind_group);
 ```
 
 <AutoGithubLink/>

--- a/docs/news/README.md
+++ b/docs/news/README.md
@@ -2,7 +2,7 @@
 
 ## 0.6
 
-This took me way to long. The changes weren't difficult, but I had to do a lot of copy pasting. The main changes are using `queue.write_buffer()` and `queue.write_texture()` everywhere. I won't get into the nitty gritty, but you can checkout the [pull request](https://github.com/sotrh/learn-wgpu/pull/90) if you're interested.
+This took me way too long. The changes weren't difficult, but I had to do a lot of copy pasting. The main changes are using `queue.write_buffer()` and `queue.write_texture()` everywhere. I won't get into the nitty gritty, but you can checkout the [pull request](https://github.com/sotrh/learn-wgpu/pull/90) if you're interested.
 
 ## Added Pong Showcase
 
@@ -16,7 +16,7 @@ My perfectionism got in my way a bit with this one. I wasn't sure that what I wa
 
 ## 0.5!
 
-To many things changed to make note of them here. Check out [the 0.5 pull request](https://github.com/sotrh/learn-wgpu/pull/29) if you're curious about specifics. That being said, 2 things are worth mentioning directly: the y-axis now points up like with DirectX and Metal, and requesting an adapter and creating a device now use `Future`s. The tutorials have been updated as well as the code.
+Too many things changed to make note of them here. Check out [the 0.5 pull request](https://github.com/sotrh/learn-wgpu/pull/29) if you're curious about specifics. That being said, 2 things are worth mentioning directly: the y-axis now points up like with DirectX and Metal, and requesting an adapter and creating a device now use `Future`s. The tutorials have been updated as well as the code.
 
 ## Reworked lighting tutorial
 
@@ -72,4 +72,3 @@ I don't know if this is a change from 0.4, but you use `wgpu = "0.4"` line in de
 
 ## New/Recent Articles
 <RecentArticles/>
-


### PR DESCRIPTION
Tutorial 2 - Swapchain
  - Update `get_next_texture` to `get_current_frame`
  - Fix typos
Tutorial 3 - Pipeline
  - Add updated fields to `PipelineLayout` creation
Fix typos in News