### PR TITLE
Update `vulkan` feature to `vulkan-portability` and fix small typo in swapchain

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -30,7 +30,7 @@ To enable the Vulkan backend, add this new section to `Cargo.toml`, and do not f
 ``` toml
 [dependencies.wgpu]
 version = "0.6"
-features = ["vulkan"]
+features = ["vulkan-portability"]
 ```
 
 - This may not be necessary because normally `wgpu-rs` validation will catch problems. In fact that is one of it's

--- a/docs/beginner/tutorial2-swapchain/README.md
+++ b/docs/beginner/tutorial2-swapchain/README.md
@@ -375,7 +375,7 @@ The `ops` field takes a `wpgu::Operations` object. This tells wgpu what to do wi
 
 <div class="note">
 
-It's not uncommon to not clear the screen if the streen is going to be completely covered up with objects. If you're scene doesn't cover the entire screen however you'll end up with something like this.
+It's not uncommon to not clear the screen if the screen is going to be completely covered up with objects. If you're scene doesn't cover the entire screen however you'll end up with something like this.
 
 ![./no-clear.png](./no-clear.png)
 


### PR DESCRIPTION
https://github.com/gfx-rs/wgpu-rs/commit/655828f88fee9d9f4a0985770fc012cc2fd6a7ec this commit renamed the `vulkan` feature which confused me when going through the initial setup.  