### PR TITLE
DeviceExt is now in a util namespace

### DIFF
--- a/docs/beginner/tutorial4-buffer/README.md
+++ b/docs/beginner/tutorial4-buffer/README.md
@@ -67,7 +67,7 @@ To access the `create_buffer_init` method on `wgpu::Device` we'll have to import
 To import the extension trait, this line somewhere near the top of `main.rs`.
 
 ```rust
-use wgpu::DeviceExt;
+use wgpu::util::DeviceExt;
 ```
 
 You'll note that we're using [bytemuck](https://docs.rs/bytemuck/1.2.0/bytemuck/) to cast our `VERTICES`. The `create_buffer_init()` method expects a `&[u8]`, and `bytemuck::cast_slice` does that for us. Add the following to your `Cargo.toml`.


### PR DESCRIPTION
While working through the tutorials I had to update this using statement as DeviceExt is now in the wgpu::util namespace.