### PR TITLE
Migration to winit 0.23

### DIFF
--- a/code/intermediate/tutorial12-camera/Cargo.toml
+++ b/code/intermediate/tutorial12-camera/Cargo.toml
@@ -14,7 +14,7 @@ image = "0.23"
 log = "0.4"
 tobj = "2.0"
 wgpu = "0.6"
-winit = "0.22"
+winit = "0.23"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/intermediate/tutorial12-camera/src/camera.rs
+++ b/code/intermediate/tutorial12-camera/src/camera.rs
@@ -1,7 +1,7 @@
 use cgmath::*;
 use std::f32::consts::FRAC_PI_2;
 use std::time::Duration;
-use winit::dpi::LogicalPosition;
+use winit::dpi::PhysicalPosition;
 use winit::event::*;
 
 #[rustfmt::skip]
@@ -143,7 +143,7 @@ impl CameraController {
         self.scroll = match delta {
             // I'm assuming a line is about 100 pixels
             MouseScrollDelta::LineDelta(_, scroll) => scroll * 100.0,
-            MouseScrollDelta::PixelDelta(LogicalPosition { y: scroll, .. }) => *scroll as f32,
+            MouseScrollDelta::PixelDelta(PhysicalPosition { y: scroll, .. }) => *scroll as f32,
         };
     }
 

--- a/code/intermediate/tutorial13-threading/Cargo.toml
+++ b/code/intermediate/tutorial13-threading/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 rayon = "1.4" # NEW!
 tobj = "2.0"
 wgpu = "0.6"
-winit = "0.22"
+winit = "0.23"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/intermediate/tutorial13-threading/src/camera.rs
+++ b/code/intermediate/tutorial13-threading/src/camera.rs
@@ -1,7 +1,7 @@
 use cgmath::*;
 use std::f32::consts::FRAC_PI_2;
 use std::time::Duration;
-use winit::dpi::LogicalPosition;
+use winit::dpi::PhysicalPosition;
 use winit::event::*;
 
 #[rustfmt::skip]
@@ -143,7 +143,7 @@ impl CameraController {
         self.scroll = -match delta {
             // I'm assuming a line is about 100 pixels
             MouseScrollDelta::LineDelta(_, scroll) => scroll * 100.0,
-            MouseScrollDelta::PixelDelta(LogicalPosition { y: scroll, .. }) => *scroll as f32,
+            MouseScrollDelta::PixelDelta(PhysicalPosition { y: scroll, .. }) => *scroll as f32,
         };
     }
 

--- a/code/showcase/framework/src/camera.rs
+++ b/code/showcase/framework/src/camera.rs
@@ -1,7 +1,7 @@
 use cgmath::*;
 use std::f32::consts::FRAC_PI_2;
 use std::time::Duration;
-use winit::dpi::LogicalPosition;
+use winit::dpi::PhysicalPosition;
 use winit::event::*;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -157,7 +157,7 @@ impl CameraController {
         self.scroll = -match delta {
             // I'm assuming a line is about 100 pixels
             MouseScrollDelta::LineDelta(_, scroll) => scroll * 100.0,
-            MouseScrollDelta::PixelDelta(LogicalPosition { y: scroll, .. }) => *scroll as f32,
+            MouseScrollDelta::PixelDelta(PhysicalPosition { y: scroll, .. }) => *scroll as f32,
         };
     }
 

--- a/docs/intermediate/tutorial12-camera/README.md
+++ b/docs/intermediate/tutorial12-camera/README.md
@@ -7,7 +7,7 @@ I've been putting this off for a while. Implementing a camera isn't specifically
 ```rust
 use cgmath::*;
 use winit::event::*;
-use winit::dpi::LogicalPosition;
+use winit::dpi::PhysicalPosition;
 use std::time::Duration;
 use std::f32::consts::FRAC_PI_2;
 
@@ -184,7 +184,7 @@ impl CameraController {
         self.scroll = -match delta {
             // I'm assuming a line is about 100 pixels
             MouseScrollDelta::LineDelta(_, scroll) => scroll * 100.0,
-            MouseScrollDelta::PixelDelta(LogicalPosition {
+            MouseScrollDelta::PixelDelta(PhysicalPosition {
                 y: scroll,
                 ..
             }) => *scroll as f32,


### PR DESCRIPTION
The new version of ```winit 0.23``` introduces breaking changes in API. They've changed field of the enum ```MouseScrollDelta::PixelDelta``` from ```LogicalPosition``` into ```PhysicalPosition```. I have only changed the files in which this problem occurs.

Also ```event_loop.primary_monitor()``` returns an ```Option``` now, but it appears in pong and decided not to touch it, because it's not related to the tutorial.