### PR TITLE
Fix a typo in the code example

### DIFF
--- a/docs/beginner/tutorial4-buffer/README.md
+++ b/docs/beginner/tutorial4-buffer/README.md
@@ -402,7 +402,7 @@ All we have to do now is update the `render()` method to use the `index_buffer`.
 ```rust
 // render()
 render_pass.set_pipeline(&self.render_pipeline);
-render_pass.set_vertex_buffer(0, self.vertex_buffer(..));
+render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
 render_pass.set_index_buffer(self.index_buffer.slice(..)); // 1.
 render_pass.draw_indexed(0..self.num_indices, 0, 0..1); // 2.
 ```


### PR DESCRIPTION
Was missing the `slice` method