### PR TITLE
Add a link to GitHub repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ I'm using this project as a way to learn wgpu myself, so I might miss some impor
 
 ## Contribution and Support
 
-* I accept pull requests for fixing issues with this tutorial such as typos, incorrect information, and other inconsistencies.
+* I accept pull requests ([GitHub repo](https://github.com/sotrh/learn-wgpu)) for fixing issues with this tutorial such as typos, incorrect information, and other inconsistencies.
 * Due to wgpu's rapidly changing api, I'm not accepting any new pull requests for showcase demos.
 * If you want to support me directly, check out my [patreon](https://www.patreon.com/sotrh)!
 


### PR DESCRIPTION
Hi, I think the learn-wgpu site has no link to this GitHub repository. I think it's easier for possible contributors to find the repo if there's a link around this section.