### PR TITLE
Misc typo and code fixes.

### DIFF
--- a/docs/intermediate/tutorial11-normals/README.md
+++ b/docs/intermediate/tutorial11-normals/README.md
@@ -1,6 +1,6 @@
 # Normal Mapping
 
-With just lighting, our scene is already looking pretty good. Still, our models are still overly smooth. This is understandable because we are using a very simple model. If we were using a texture that was supposed to be smooth, this wouldn't be a problem, but our brick texture is supposed to be rougher. We could solve this by adding more geometry, but that would slow our scene down, and it would hard to know where to add new polygons. This is were normal mapping comes in.
+With just lighting, our scene is already looking pretty good. Still, our models are still overly smooth. This is understandable because we are using a very simple model. If we were using a texture that was supposed to be smooth, this wouldn't be a problem, but our brick texture is supposed to be rougher. We could solve this by adding more geometry, but that would slow our scene down, and it be would hard to know where to add new polygons. This is were normal mapping comes in.
 
 Remember in [the instancing tutorial](/beginner/tutorial7-instancing/#a-different-way-textures), we experimented with storing instance data in a texture? A normal map is doing just that with normal data! We'll use the normals in the normal map in our lighting calculation in addition to the vertex normal.
 
@@ -52,7 +52,7 @@ let texture_bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroup
 });
 ```
 
-We'll need to actually the normal map itself. We'll do this in the loop we create the materials in.
+We'll need to actually load the normal map. We'll do this in the loop we create the materials in.
 
 ```rust
     let diffuse_path = mat.diffuse_texture;
@@ -63,7 +63,7 @@ We'll need to actually the normal map itself. We'll do this in the loop we creat
 
 ```
 
-* Note: I duplicated and moved teh `command_buffers.push(cmds);` line. This means we can reuse the `cmds` variable for both the normal map and diffuse/color map.
+* Note: I duplicated and moved the `command_buffers.push(cmds);` line. This means we can reuse the `cmds` variable for both the normal map and diffuse/color map.
 
 Our `Material`'s `bind_group` will have to change as well. 
 
@@ -208,7 +208,7 @@ impl Model {
         queue: &wgpu::Queue,
         layout: &wgpu::BindGroupLayout,
         path: P,
-    ) -> Result<(Self, Vec<wgpu::CommandBuffer>), failure::Error> {
+    ) -> Result<Self> {
         // ...
         for m in obj_models {
             let mut vertices = Vec::new();
@@ -281,7 +281,7 @@ impl Model {
             // ...
         }
 
-        Ok((Self { meshes, materials }, command_buffers))
+        Ok(Self { meshes, materials })
     }
 }
 ```
@@ -436,7 +436,6 @@ pub fn from_image(
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         label,
         size,
-        array_layer_count: 1,
         mip_level_count: 1,
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,

--- a/docs/intermediate/tutorial12-camera/README.md
+++ b/docs/intermediate/tutorial12-camera/README.md
@@ -109,7 +109,7 @@ You can tell the difference between a right-handed coordinate system and a left-
 
 # The Camera Controller
 
-As our camera is different, so we'll need a new camera controller. Add the following to `camera.rs`.
+Our camera is different, so we'll need a new camera controller. Add the following to `camera.rs`.
 
 ```rust
 #[derive(Debug)]
@@ -253,8 +253,8 @@ impl Uniforms {
 
     // UPDATED!
     fn update_view_proj(&mut self, camera: &camera::Camera, projection: &camera::Projection) {
-        self.view_position = camera.position.to_homogeneous();
-        self.view_proj = projection.calc_matrix() * camera.calc_matrix()
+        self.view_position = camera.position.to_homogeneous().into();
+        self.view_proj = (projection.calc_matrix() * camera.calc_matrix()).into();
     }
 }
 ```
@@ -289,14 +289,17 @@ impl State {
 
         // ...
 
+        uniforms.update_view_proj(&camera, &projection); // UPDATED!
+
+        // ...
+
         Self {
             // ...
             camera,
-            projection,
+            projection, // NEW!
             camera_controller,
             // ...
-            // NEW!
-            mouse_pressed: false,
+            mouse_pressed: false, // NEW!
         }
     }
 }
@@ -326,7 +329,7 @@ fn input(&mut self, event: &DeviceEvent) -> bool {
             }
         ) => self.camera_controller.process_keyboard(*key, *state),
         DeviceEvent::MouseWheel { delta, .. } => {
-            self.camera_controller.process_scroll(delta);
+            self.camera_controller.process_scroll(*delta);
             true
         }
         DeviceEvent::Button {

--- a/docs/intermediate/tutorial13-threading/README.md
+++ b/docs/intermediate/tutorial13-threading/README.md
@@ -167,7 +167,19 @@ impl Model {
                 }
             }).collect::<Vec<_>>();
             // ...
-        }
+            let index_buffer = device.create_buffer_init(
+                &wgpu::util::BufferInitDescriptor {
+                    label: Some(&format!("{:?} Index Buffer", m.name)), // UPDATED!
+                    contents: bytemuck::cast_slice(&m.mesh.indices),
+                    usage: wgpu::BufferUsage::INDEX,
+                }
+            );
+            // ...
+            // UPDATED!
+            Ok(Mesh {
+                // ...
+            })
+        }).collect::<Result<Vec<_>>>()?;
         // ...
     }
     // ...


### PR DESCRIPTION
Hey @sotrh! I just finished going through your tutorials and they're great! I have a few edits to suggest. Most of them were either code typos I found that were fixed in the `src` folders but not in the code snippets, and the rare text typo.

Feel free to ask me to revert any of these changes. They're pretty minor, I just figured other folks would appreciate the updates.

009: impl Vertex for ModelVertex was using the vertex_attr_array! macro.
009: RenderPipelineDescriptor has a `vertex` member not  `vertex_state`.
009: to_rgba() should be to_rgba8(), to_rgba is set to be deprecated.

010: BindGroupDescriptor has a `entries` member not `bindings`.
010: Remove re-declaration of mat4 model_matrix;
010: Prefer hard-coded [#.#; #] instead of `Foo::fn().into()`.
010: Clarify which shader frag/vert file changes are in.

011: Change Model::load return type to Result<Self>.
011: TextureDescriptor does not have a array_layer_count member.

012: Add .into() to calls in Uniforms::update_view_proj().
012: Dereference delta variable in State::input().

013: Add more changed lines to Model::load to avoid compiler yelling.