### PR TITLE
Update winit to 0.24 and wgpu to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,9 +3294,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4132,9 +4132,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60007fc3748278a36b458d96f86105f43aa5f0e412b15a5f934950d61ec26a9"
+checksum = "79a0a0a63fac9492cfaf6e7e4bdf9729c128f1e94124b9e4cbc4004b8cb6d1d8"
 dependencies = [
  "arrayvec",
  "js-sys",
@@ -4143,6 +4143,7 @@ dependencies = [
  "raw-window-handle",
  "serde",
  "smallvec",
+ "syn",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,36 +80,16 @@ dependencies = [
 
 [[package]]
 name = "andrew"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7f09f89872c2b6b29e319377b1fbe91c6f5947df19a25596e121cf19a7b35e"
-dependencies = [
- "bitflags",
- "line_drawing",
- "rusttype 0.7.9",
- "walkdir",
- "xdg",
- "xml-rs",
-]
-
-[[package]]
-name = "andrew"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4afb09dd642feec8408e33f92f3ffc4052946f6b20f32fb99c1f58cd4fa7cf"
 dependencies = [
  "bitflags",
- "rusttype 0.9.2",
+ "rusttype",
  "walkdir",
  "xdg",
  "xml-rs",
 ]
-
-[[package]]
-name = "android_log-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e"
 
 [[package]]
 name = "ansi_term"
@@ -233,8 +213,8 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -288,8 +268,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dae23a39becf0b1c8f9198d7e9fc80aaf1ec1ee7428ec570f6a0269e59a9cc"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -304,17 +284,6 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
-
-[[package]]
-name = "calloop"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa2097be53a00de9e8fc349fea6d76221f398f5c4fa550d420669906962d160"
-dependencies = [
- "mio",
- "mio-extras",
- "nix 0.14.1",
-]
 
 [[package]]
 name = "calloop"
@@ -460,37 +429,6 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c49e86fc36d5704151f5996b7b3795385f50ce09e3be0f47a0cfde869681cf8"
-dependencies = [
- "bitflags",
- "block",
- "core-foundation 0.7.0",
- "core-graphics 0.19.2",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54201c07dcf3a5ca33fececb8042aed767ee4bfd5a0235a8ceabcda956044b2"
-dependencies = [
- "bitflags",
- "block",
- "cocoa-foundation",
- "core-foundation 0.9.0",
- "core-graphics 0.22.1",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
@@ -566,7 +504,7 @@ dependencies = [
  "shaderc",
  "tobj",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -729,11 +667,11 @@ dependencies = [
  "lazy_static",
  "libc",
  "mach",
- "ndk 0.2.1",
- "ndk-glue 0.2.1",
+ "ndk",
+ "ndk-glue",
  "nix 0.15.0",
  "oboe",
- "parking_lot 0.11.0",
+ "parking_lot",
  "stdweb 0.1.3",
  "thiserror",
  "web-sys",
@@ -872,8 +810,8 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "strsim",
  "syn",
 ]
@@ -885,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
- "quote 1.0.7",
+ "quote",
  "syn",
 ]
 
@@ -905,8 +843,8 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1058,7 +996,7 @@ dependencies = [
  "tobj",
  "wgpu",
  "wgpu-subscriber",
- "winit 0.24.0",
+ "winit",
 ]
 
 [[package]]
@@ -1144,8 +1082,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1251,7 +1189,7 @@ dependencies = [
  "gfx-hal",
  "libloading 0.6.2",
  "log",
- "parking_lot 0.11.0",
+ "parking_lot",
  "range-alloc",
  "raw-window-handle",
  "smallvec",
@@ -1274,7 +1212,7 @@ dependencies = [
  "gfx-auxil",
  "gfx-hal",
  "log",
- "parking_lot 0.11.0",
+ "parking_lot",
  "range-alloc",
  "raw-window-handle",
  "smallvec",
@@ -1309,7 +1247,7 @@ dependencies = [
  "libloading 0.6.2",
  "log",
  "naga",
- "parking_lot 0.11.0",
+ "parking_lot",
  "raw-window-handle",
  "spirv_cross",
  "wasm-bindgen",
@@ -1334,7 +1272,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot 0.11.0",
+ "parking_lot",
  "range-alloc",
  "raw-window-handle",
  "spirv_cross",
@@ -1356,7 +1294,7 @@ dependencies = [
  "log",
  "naga",
  "objc",
- "parking_lot 0.11.0",
+ "parking_lot",
  "raw-window-handle",
  "smallvec",
  "winapi 0.3.9",
@@ -1402,7 +1340,7 @@ dependencies = [
  "shaderc",
  "tobj",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -1591,7 +1529,7 @@ checksum = "24cfcf6e3326886321c5d637caf1ce217006651059015fae372b1c49c0e722b2"
 dependencies = [
  "bitflags",
  "imgui-sys",
- "parking_lot 0.11.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1637,7 +1575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d632440e05c964e8a7f00f2659c4f71c97897d8c38a77a0c2dc1f3fe8d632208"
 dependencies = [
  "imgui",
- "winit 0.24.0",
+ "winit",
 ]
 
 [[package]]
@@ -1826,28 +1764,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "line_drawing"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7ad3d82c845bdb5dde34ffdcc7a5fb4d2996e1e1ee0f19c33bc80e15196b9"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
-
-[[package]]
-name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "lock_api"
@@ -2064,39 +1984,14 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a356cafe20aee088789830bfea3a61336e84ded9e545e00d3869ce95dcb80c"
-dependencies = [
- "jni-sys",
- "ndk-sys 0.1.0",
- "num_enum",
-]
-
-[[package]]
-name = "ndk"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb167c1febed0a496639034d0c76b3b74263636045db5489eee52143c246e73"
 dependencies = [
  "jni-sys",
- "ndk-sys 0.2.1",
+ "ndk-sys",
  "num_enum",
  "thiserror",
-]
-
-[[package]]
-name = "ndk-glue"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1730ee2e3de41c3321160a6da815f008c4006d71b095880ea50e17cf52332b8"
-dependencies = [
- "android_log-sys",
- "lazy_static",
- "libc",
- "log",
- "ndk 0.1.0",
- "ndk-sys 0.1.0",
 ]
 
 [[package]]
@@ -2108,9 +2003,9 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "ndk 0.2.1",
+ "ndk",
  "ndk-macro",
- "ndk-sys 0.2.1",
+ "ndk-sys",
 ]
 
 [[package]]
@@ -2121,16 +2016,10 @@ checksum = "05d1c6307dc424d0f65b9b06e94f88248e6305726b14729fd67a5e47b2dc481d"
 dependencies = [
  "darling",
  "proc-macro-crate",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
-
-[[package]]
-name = "ndk-sys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2820aca934aba5ed91c79acc72b6a44048ceacc5d36c035ed4e051f12d887d"
 
 [[package]]
 name = "ndk-sys"
@@ -2147,19 +2036,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "nix"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
 ]
 
 [[package]]
@@ -2203,8 +2079,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -2276,8 +2152,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -2313,8 +2189,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aadc2b0867bdbb9a81c4d99b9b682958f49dbea1295a81d2f646cca2afdd9fc"
 dependencies = [
  "jni 0.14.0",
- "ndk 0.2.1",
- "ndk-glue 0.2.1",
+ "ndk",
+ "ndk-glue",
  "num-derive",
  "num-traits",
  "oboe-sys",
@@ -2373,37 +2249,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
 dependencies = [
  "instant",
- "lock_api 0.4.1",
- "parking_lot_core 0.8.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi 0.0.3",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2458,8 +2310,8 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -2502,7 +2354,7 @@ dependencies = [
  "shaderc",
  "wgpu",
  "wgpu_glyph",
- "winit 0.24.0",
+ "winit",
 ]
 
 [[package]]
@@ -2534,20 +2386,11 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2577,20 +2420,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -2953,26 +2787,6 @@ dependencies = [
 
 [[package]]
 name = "rusttype"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310942406a39981bed7e12b09182a221a29e0990f3e7e0c971f131922ed135d5"
-dependencies = [
- "rusttype 0.8.3",
-]
-
-[[package]]
-name = "rusttype"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f61411055101f7b60ecf1041d87fb74205fb20b0c7a723f07ef39174cf6b4c0"
-dependencies = [
- "approx 0.3.2",
- "ordered-float",
- "stb_truetype",
-]
-
-[[package]]
-name = "rusttype"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc7c727aded0be18c5b80c1640eae0ac8e396abf6fa8477d96cb37d18ee5ec59"
@@ -3054,8 +2868,8 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3143,38 +2957,22 @@ checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421c8dc7acf5cb205b88160f8b4cc2c5cfabe210e43b2f80f009f4c1ef910f1d"
-dependencies = [
- "andrew 0.2.1",
- "bitflags",
- "dlib",
- "lazy_static",
- "memmap",
- "nix 0.14.1",
- "wayland-client 0.23.6",
- "wayland-protocols 0.23.6",
-]
-
-[[package]]
-name = "smithay-client-toolkit"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ec5c077def8af49f9b5aeeb5fcf8079c638c6615c3a8f9305e2dea601de57f7"
 dependencies = [
- "andrew 0.3.1",
+ "andrew",
  "bitflags",
  "byteorder",
- "calloop 0.6.5",
+ "calloop",
  "dlib",
  "lazy_static",
  "log",
  "memmap",
  "nix 0.18.0",
- "wayland-client 0.28.2",
+ "wayland-client",
  "wayland-cursor",
- "wayland-protocols 0.28.2",
+ "wayland-protocols",
 ]
 
 [[package]]
@@ -3214,15 +3012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stb_truetype"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77b6b07e862c66a9f3e62a07588fee67cd90a9135a2b942409f195507b4fb51"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3248,8 +3037,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "serde",
  "serde_derive",
  "syn",
@@ -3262,8 +3051,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3283,7 +3072,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418bb14643aa55a7841d5303f72cf512cfb323b8cc221d51580500a1ca75206c"
 dependencies = [
- "lock_api 0.4.1",
+ "lock_api",
 ]
 
 [[package]]
@@ -3298,9 +3087,9 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "unicode-xid 0.2.1",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3338,8 +3127,8 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3423,8 +3212,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "standback",
  "syn",
 ]
@@ -3482,8 +3271,8 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3562,7 +3351,7 @@ dependencies = [
  "log",
  "shaderc",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3581,7 +3370,7 @@ dependencies = [
  "shaderc",
  "tobj",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3600,7 +3389,7 @@ dependencies = [
  "shaderc",
  "tobj",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3619,7 +3408,7 @@ dependencies = [
  "shaderc",
  "tobj",
  "wgpu",
- "winit 0.23.0",
+ "winit",
 ]
 
 [[package]]
@@ -3639,7 +3428,7 @@ dependencies = [
  "shaderc",
  "tobj",
  "wgpu",
- "winit 0.23.0",
+ "winit",
 ]
 
 [[package]]
@@ -3653,7 +3442,7 @@ dependencies = [
  "log",
  "shaderc",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3670,7 +3459,7 @@ dependencies = [
  "log",
  "shaderc",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3688,7 +3477,7 @@ dependencies = [
  "log",
  "shaderc",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3706,7 +3495,7 @@ dependencies = [
  "log",
  "shaderc",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3724,7 +3513,7 @@ dependencies = [
  "log",
  "shaderc",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3742,7 +3531,7 @@ dependencies = [
  "log",
  "shaderc",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3760,7 +3549,7 @@ dependencies = [
  "log",
  "shaderc",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3779,7 +3568,7 @@ dependencies = [
  "shaderc",
  "tobj",
  "wgpu",
- "winit 0.22.2",
+ "winit",
 ]
 
 [[package]]
@@ -3808,12 +3597,6 @@ checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec 1.1.1",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -3921,8 +3704,8 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
  "wasm-bindgen-shared",
 ]
@@ -3945,7 +3728,7 @@ version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
- "quote 1.0.7",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3955,8 +3738,8 @@ version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -3970,23 +3753,6 @@ checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wayland-client"
-version = "0.23.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1080ebe0efabcf12aef2132152f616038f2d7dcbbccf7b2d8c5270fe14bcda"
-dependencies = [
- "bitflags",
- "calloop 0.4.4",
- "downcast-rs",
- "libc",
- "mio",
- "nix 0.14.1",
- "wayland-commons 0.23.6",
- "wayland-scanner 0.23.6",
- "wayland-sys 0.23.6",
-]
-
-[[package]]
-name = "wayland-client"
 version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222b227f47871e47d657c1c5e5360b4af9a877aa9c892716787be1c192c78c42"
@@ -3996,19 +3762,9 @@ dependencies = [
  "libc",
  "nix 0.18.0",
  "scoped-tls",
- "wayland-commons 0.28.2",
- "wayland-scanner 0.28.2",
- "wayland-sys 0.28.2",
-]
-
-[[package]]
-name = "wayland-commons"
-version = "0.23.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb66b0d1a27c39bbce712b6372131c6e25149f03ffb0cd017cf8f7de8d66dbdb"
-dependencies = [
- "nix 0.14.1",
- "wayland-sys 0.23.6",
+ "wayland-commons",
+ "wayland-scanner",
+ "wayland-sys",
 ]
 
 [[package]]
@@ -4020,7 +3776,7 @@ dependencies = [
  "nix 0.18.0",
  "once_cell",
  "smallvec",
- "wayland-sys 0.28.2",
+ "wayland-sys",
 ]
 
 [[package]]
@@ -4030,20 +3786,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aad1b4301cdccfb5f64056a4736e8155a5f4734bac41fdbca80b1fdbe1ab3e1"
 dependencies = [
  "nix 0.18.0",
- "wayland-client 0.28.2",
+ "wayland-client",
  "xcursor",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.23.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc286643656742777d55dc8e70d144fa4699e426ca8e9d4ef454f4bf15ffcf9"
-dependencies = [
- "bitflags",
- "wayland-client 0.23.6",
- "wayland-commons 0.23.6",
- "wayland-scanner 0.23.6",
 ]
 
 [[package]]
@@ -4053,20 +3797,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc16a9db803cae58b45f9a84a6cf364434cc49a95c8b1ef98ffeb467d228bdc9"
 dependencies = [
  "bitflags",
- "wayland-client 0.28.2",
- "wayland-commons 0.28.2",
- "wayland-scanner 0.28.2",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.23.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b02247366f395b9258054f964fe293ddd019c3237afba9be2ccbe9e1651c3d"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "xml-rs",
+ "wayland-client",
+ "wayland-commons",
+ "wayland-scanner",
 ]
 
 [[package]]
@@ -4075,19 +3808,9 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee5bd43a1d746efc486515fec561e47205f328b74802b959f10f5500f7e56cc"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
+ "proc-macro2",
+ "quote",
  "xml-rs",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.23.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94e89a86e6d6d7c7c9b19ebf48a03afaac4af6bc22ae570e9a24124b75358f4"
-dependencies = [
- "dlib",
- "lazy_static",
 ]
 
 [[package]]
@@ -4139,7 +3862,7 @@ dependencies = [
  "arrayvec",
  "js-sys",
  "naga",
- "parking_lot 0.11.0",
+ "parking_lot",
  "raw-window-handle",
  "serde",
  "smallvec",
@@ -4173,7 +3896,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-descriptor",
  "naga",
- "parking_lot 0.11.0",
+ "parking_lot",
  "raw-window-handle",
  "ron",
  "serde",
@@ -4189,7 +3912,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91955b0d6480d86e577bbd0b0d1dd5acd0699c054610dc8673c4c3366295ed27"
 dependencies = [
- "parking_lot 0.11.0",
+ "parking_lot",
  "thread-id",
  "tracing",
  "tracing-log",
@@ -4271,69 +3994,7 @@ dependencies = [
  "raw-window-handle",
  "shaderc",
  "wgpu",
- "winit 0.24.0",
-]
-
-[[package]]
-name = "winit"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4ccbf7ddb6627828eace16cacde80fc6bf4dbb3469f88487262a02cf8e7862"
-dependencies = [
- "bitflags",
- "cocoa 0.20.2",
- "core-foundation 0.7.0",
- "core-graphics 0.19.2",
- "core-video-sys",
- "dispatch",
- "instant",
- "lazy_static",
- "libc",
- "log",
- "mio",
- "mio-extras",
- "ndk 0.1.0",
- "ndk-glue 0.1.0",
- "ndk-sys 0.1.0",
- "objc",
- "parking_lot 0.10.2",
- "percent-encoding",
- "raw-window-handle",
- "smithay-client-toolkit 0.6.6",
- "wayland-client 0.23.6",
- "winapi 0.3.9",
- "x11-dl",
-]
-
-[[package]]
-name = "winit"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bc559da567d8aa671bbcd08304d49e982c7bf2cb91e10288b9188931c1b772"
-dependencies = [
- "bitflags",
- "cocoa 0.23.0",
- "core-foundation 0.9.0",
- "core-graphics 0.22.1",
- "core-video-sys",
- "dispatch",
- "instant",
- "lazy_static",
- "libc",
- "log",
- "mio",
- "mio-extras",
- "ndk 0.2.1",
- "ndk-glue 0.2.1",
- "ndk-sys 0.2.1",
- "objc",
- "parking_lot 0.11.0",
- "percent-encoding",
- "raw-window-handle",
- "smithay-client-toolkit 0.12.0",
- "wayland-client 0.28.2",
- "winapi 0.3.9",
- "x11-dl",
+ "winit",
 ]
 
 [[package]]
@@ -4343,7 +4004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da4eda6fce0eb84bd0a33e3c8794eb902e1033d0a1d5a31bc4f19b1b4bbff597"
 dependencies = [
  "bitflags",
- "cocoa 0.24.0",
+ "cocoa",
  "core-foundation 0.9.0",
  "core-graphics 0.22.1",
  "core-video-sys",
@@ -4354,15 +4015,15 @@ dependencies = [
  "log",
  "mio",
  "mio-extras",
- "ndk 0.2.1",
- "ndk-glue 0.2.1",
- "ndk-sys 0.2.1",
+ "ndk",
+ "ndk-glue",
+ "ndk-sys",
  "objc",
- "parking_lot 0.11.0",
+ "parking_lot",
  "percent-encoding",
  "raw-window-handle",
- "smithay-client-toolkit 0.12.0",
- "wayland-client 0.28.2",
+ "smithay-client-toolkit",
+ "wayland-client",
  "winapi 0.3.9",
  "x11-dl",
 ]

--- a/code/beginner/tutorial1-window/Cargo.toml
+++ b/code/beginner/tutorial1-window/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 image = "0.23"
-winit = "0.22"
+winit = "0.24"
 shaderc = "0.7"
 cgmath = "0.17"
 env_logger = "0.7"

--- a/code/beginner/tutorial2-swapchain/Cargo.toml
+++ b/code/beginner/tutorial2-swapchain/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 image = "0.23"
-winit = "0.22"
+winit = "0.24"
 shaderc = "0.7"
 cgmath = "0.17"
 env_logger = "0.7"

--- a/code/beginner/tutorial3-pipeline/Cargo.toml
+++ b/code/beginner/tutorial3-pipeline/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 image = "0.23"
-winit = "0.22"
+winit = "0.24"
 # shaderc = "0.7" # REMOVED!
 cgmath = "0.17"
 env_logger = "0.7"

--- a/code/beginner/tutorial4-buffer/Cargo.toml
+++ b/code/beginner/tutorial4-buffer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 image = "0.23"
-winit = "0.22"
+winit = "0.24"
 cgmath = "0.17"
 wgpu = "0.7"
 env_logger = "0.7"

--- a/code/beginner/tutorial5-textures/Cargo.toml
+++ b/code/beginner/tutorial5-textures/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 futures = "0.3"
 image = "0.23"
 wgpu = "0.7"
-winit = "0.22"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/beginner/tutorial6-uniforms/Cargo.toml
+++ b/code/beginner/tutorial6-uniforms/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 futures = "0.3"
 image = "0.23"
 wgpu = "0.7"
-winit = "0.22"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/beginner/tutorial7-instancing/Cargo.toml
+++ b/code/beginner/tutorial7-instancing/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 futures = "0.3"
 image = "0.23"
 wgpu = "0.7"
-winit = "0.22"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/beginner/tutorial8-depth/Cargo.toml
+++ b/code/beginner/tutorial8-depth/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3"
 image = "0.23"
 log = "0.4"
 wgpu = "0.7"
-winit = "0.22"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/beginner/tutorial9-models/Cargo.toml
+++ b/code/beginner/tutorial9-models/Cargo.toml
@@ -14,7 +14,7 @@ image = "0.23"
 log = "0.4"
 tobj = "2.0"
 wgpu = "0.7"
-winit = "0.22"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/intermediate/tutorial10-lighting/Cargo.toml
+++ b/code/intermediate/tutorial10-lighting/Cargo.toml
@@ -14,7 +14,7 @@ image = "0.23"
 log = "0.4"
 tobj = "2.0"
 wgpu = "0.7"
-winit = "0.22"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/intermediate/tutorial11-normals/Cargo.toml
+++ b/code/intermediate/tutorial11-normals/Cargo.toml
@@ -14,7 +14,7 @@ image = "0.23"
 log = "0.4"
 tobj = "2.0"
 wgpu = "0.7"
-winit = "0.22"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/intermediate/tutorial12-camera/Cargo.toml
+++ b/code/intermediate/tutorial12-camera/Cargo.toml
@@ -14,7 +14,7 @@ image = "0.23"
 log = "0.4"
 tobj = "2.0"
 wgpu = "0.7"
-winit = "0.23"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/intermediate/tutorial13-threading/Cargo.toml
+++ b/code/intermediate/tutorial13-threading/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 rayon = "1.4" # NEW!
 tobj = "2.0"
 wgpu = "0.7"
-winit = "0.23"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/showcase/compute/Cargo.toml
+++ b/code/showcase/compute/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 rayon = "1.4"
 tobj = "2.0"
 wgpu = { version = "0.7", features = ["trace"] }
-winit = "0.22"
+winit = "0.24"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/code/showcase/compute/src/camera.rs
+++ b/code/showcase/compute/src/camera.rs
@@ -1,7 +1,7 @@
 use cgmath::*;
 use std::f32::consts::FRAC_PI_2;
 use std::time::Duration;
-use winit::dpi::LogicalPosition;
+use winit::dpi::PhysicalPosition;
 use winit::event::*;
 
 #[rustfmt::skip]
@@ -143,7 +143,7 @@ impl CameraController {
         self.scroll = -match delta {
             // I'm assuming a line is about 100 pixels
             MouseScrollDelta::LineDelta(_, scroll) => scroll * 100.0,
-            MouseScrollDelta::PixelDelta(LogicalPosition { y: scroll, .. }) => *scroll as f32,
+            MouseScrollDelta::PixelDelta(PhysicalPosition { y: scroll, .. }) => *scroll as f32,
         };
     }
 

--- a/code/showcase/gifs/Cargo.toml
+++ b/code/showcase/gifs/Cargo.toml
@@ -15,7 +15,7 @@ image = "0.23"
 log = "0.4"
 tobj = "2.0"
 wgpu = "0.7"
-winit = "0.22"
+winit = "0.24"
 gif = "0.10.3"
 
 framework = { version = "0.1.0", path = "../framework" }

--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -9,7 +9,7 @@ For the beginner stuff, we're going to keep things very simple, we'll add things
 ```toml
 [dependencies]
 image = "0.23"
-winit = "0.22"
+winit = "0.24"
 shaderc = "0.7"
 cgmath = "0.17"
 env_logger = "0.7"

--- a/docs/beginner/tutorial3-pipeline/README.md
+++ b/docs/beginner/tutorial3-pipeline/README.md
@@ -276,7 +276,7 @@ We'll start writing code in it in a bit. First we need to add some things to our
 ```toml
 [dependencies]
 image = "0.23"
-winit = "0.22"
+winit = "0.24"
 # shaderc = "0.7" # REMOVED!
 cgmath = "0.17"
 wgpu = "0.7"

--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -424,7 +424,7 @@ For convenience sake, let's pull our texture code into its module. We'll first n
 ```toml
 [dependencies]
 image = "0.23"
-winit = "0.22"
+winit = "0.24"
 cgmath = "0.17"
 env_logger = "0.7"
 log = "0.4"

--- a/docs/intermediate/tutorial12-camera/README.md
+++ b/docs/intermediate/tutorial12-camera/README.md
@@ -315,7 +315,7 @@ fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
 }
 ```
 
-`input()` will need to be updated as well. Up to this point we have been using `WindowEvent`s for our camera controls. While this works, it's not the best solution. The [winit docs](https://docs.rs/winit/0.23.0/winit/event/enum.WindowEvent.html?search=#variant.CursorMoved) inform us that OS will often transform the data for the `CursorMoved` event to allow effects such as cursor acceleration. Because of this, we're going to change our `input()` function to use `DeviceEvent` instead of `WindowEvent`.
+`input()` will need to be updated as well. Up to this point we have been using `WindowEvent`s for our camera controls. While this works, it's not the best solution. The [winit docs](https://docs.rs/winit/0.24.0/winit/event/enum.WindowEvent.html?search=#variant.CursorMoved) inform us that OS will often transform the data for the `CursorMoved` event to allow effects such as cursor acceleration. Because of this, we're going to change our `input()` function to use `DeviceEvent` instead of `WindowEvent`.
 
 ```rust
 // UPDATED!


### PR DESCRIPTION
Fix #160 

It seems there's no breaking change between winit 0.22 and 0.24 except for this one:

> Breaking: PixelDelta scroll events now return a PhysicalPosition.
(https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#0230-2020-10-02)

I think it's okay to use `PhysicalPosition` instead of `LogicalPosition`, but if the latter is preferred, I'll find how to convert them.

Also, this pull request updates wgpu to 0.7.1. This is because current Cargo.toml specifies:

``` toml
wgpu = "0.7"
```

so users who started the tutorial recently uses 0.7.1. It seems there's no visible difference, but I think it's good to match the actual version.