### PR TITLE
wgpu 0.8 corrections

### DIFF
--- a/docs/beginner/tutorial3-pipeline/README.md
+++ b/docs/beginner/tutorial3-pipeline/README.md
@@ -1,7 +1,7 @@
 # The Pipeline
 
 ## What's a pipeline?
-If you're familiar with OpenGL, you may remember using shader programs. You can think of a pipeline as a more robust version of that. A pipeline describes all the actions the gpu will preform when acting on a set of data. In this section, we will be creating a `RenderPipeline` specifically.
+If you're familiar with OpenGL, you may remember using shader programs. You can think of a pipeline as a more robust version of that. A pipeline describes all the actions the gpu will perform when acting on a set of data. In this section, we will be creating a `RenderPipeline` specifically.
 
 ## Wait shaders?
 Shaders are mini programs that you send to the gpu to perform operations on your data. There are 3 main types of shader: vertex, fragment, and compute. There are others such as geometry shaders, but they're more of an advanced topic. For now we're just going to use vertex, and fragment shaders.
@@ -175,8 +175,7 @@ let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescrip
         entry_point: "main",
         targets: &[wgpu::ColorTargetState { // 4.
             format: sc_desc.format,
-            alpha_blend: wgpu::BlendState::REPLACE,
-            color_blend: wgpu::BlendState::REPLACE,
+            blend: Some(wgpu::BlendState::REPLACE),
             write_mask: wgpu::ColorWrite::ALL,
         }],
     }),

--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -492,8 +492,8 @@ impl Texture {
             rgba,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: NonZeroU32::new(4 * dimensions.0),
-                rows_per_image: NonZeroU32::new(dimensions.1),
+                bytes_per_row: std::num::NonZeroU32::new(4 * dimensions.0),
+                rows_per_image: std::num::NonZeroU32::new(dimensions.1),
             },
             size,
         );

--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -70,8 +70,8 @@ queue.write_texture(
     // The layout of the texture
     wgpu::ImageDataLayout {
         offset: 0,
-        bytes_per_row: 4 * dimensions.0,
-        rows_per_image: dimensions.1,
+        bytes_per_row: std::num::NonZeroU32::new(4 * dimensions.0),
+        rows_per_image: std::num::NonZeroU32::new(dimensions.1),
     },
     texture_size,
 );

--- a/docs/beginner/tutorial6-uniforms/README.md
+++ b/docs/beginner/tutorial6-uniforms/README.md
@@ -257,7 +257,7 @@ fn main(
 }
 ```
 
-1. The according to the [WGSL Spec](https://gpuweb.github.io/gpuweb/wgsl/), The block decorator indicates this structure type represents the contents of a buffer resource occupying a single binding slot in the shader’s resource interface. Any structure used as a `uniform` must be annotated with `[[block]]`
+1. According to the [WGSL Spec](https://gpuweb.github.io/gpuweb/wgsl/), The block decorator indicates this structure type represents the contents of a buffer resource occupying a single binding slot in the shader’s resource interface. Any structure used as a `uniform` must be annotated with `[[block]]`
 2. Because we've created a new bind group, we need to specify which one we're using in the shader. The number is determined by our `render_pipeline_layout`. The `texture_bind_group_layout` is listed first, thus it's `group(0)`, and `uniform_bind_group` is second, so it's `group(1)`.
 3. Multiplication order is important when it comes to matrices. The vector goes on the right, and the matrices gone on the left in order of importance.
 


### PR DESCRIPTION
Following the tutorial I found the `wgpu::ColorTargetState` struct construction was out of date, as the color and alpha components had been moved inside `BlendState`.