### PR TITLE
Add missing fields in PrimitiveState

### DIFF
--- a/docs/beginner/tutorial3-pipeline/README.md
+++ b/docs/beginner/tutorial3-pipeline/README.md
@@ -196,6 +196,10 @@ Two things to note here:
         cull_mode: Some(wgpu::Face::Back),
         // Setting this to anything other than Fill requires Features::NON_FILL_POLYGON_MODE
         polygon_mode: wgpu::PolygonMode::Fill,
+        // Requires Features::DEPTH_CLAMPING
+        clamp_depth: false,
+        // Requires Features::CONSERVATIVE_RASTERIZATION
+        conservative: false,
     },
     // continued ...
 ```


### PR DESCRIPTION
The render pipeline page was missing the `clamp_depth` and `conservative` fields of the `wgpu::PrimitiveState` struct, added with wgpu 0.8.  These were correct in the full code, but not the snippets in the doc.