### PR TITLE
Update README.md

### DIFF
--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -298,7 +298,7 @@ First, we'll change the `Vertex` struct:
 
 ```rust
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 struct Vertex {
     position: [f32; 3],
     tex_coords: [f32; 2], // NEW!


### PR DESCRIPTION
When the vertex class is updated, the `bytemuck` traits were missing