### PR TITLE
Proposition to update beginner swapchain resize to fix window minimise

### DIFF
--- a/docs/beginner/tutorial2-swapchain/README.md
+++ b/docs/beginner/tutorial2-swapchain/README.md
@@ -145,9 +145,14 @@ If we want to support resizing in our application, we're going to need to recrea
 ```rust
 // impl State
 fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
+    // Check if we are positive for the new size value
+    // otherwise when minimise the window may crash
+    let safe_width = if new_size.width > 0 { new_size.width } else { 1 };
+    let safe_height = if new_size.height > 0 { new_size.height } else { 1 };
+
     self.size = new_size;
-    self.sc_desc.width = new_size.width;
-    self.sc_desc.height = new_size.height;
+    self.sc_desc.width = safe_width;
+    self.sc_desc.height = safe_height;
     self.swap_chain = self.device.create_swap_chain(&self.surface, &self.sc_desc);
 }
 ```
@@ -312,7 +317,10 @@ event_loop.run(move |event, _, control_flow| {
                 Err(wgpu::SwapChainError::Lost) => state.resize(state.size),
                 // The system is out of memory, we should probably quit
                 Err(wgpu::SwapChainError::OutOfMemory) => *control_flow = ControlFlow::Exit,
-                // All other errors (Outdated, Timeout) should be resolved by the next frame
+                // Add the match for the Outdated error otherwise a spam of this error will happen
+                // if the window become minimise.
+                Err(wgpu::SwapChainError::Outdated) => state.resize(state.size),
+                // All other errors (Timeout) should be resolved by the next frame
                 Err(e) => eprintln!("{:?}", e),
             }
         }


### PR DESCRIPTION
## The swapchain beginner doc update proposition

If you don't check the if size is safe before updated it, wgpu will throw a error and make crash your window

 `
thread 'main' panicked at 'Index 0 is already occupied', C:\Users\olivi\.cargo\registry\src\github.com-1ecc6299db9ec823\wgpu-core-0.9.2\src\hub.rs:169:18
`

This fix can make stop this behavior but you will now have a spam of Outdated message error if you run and try to minimise the window.

So the second update in the doc is to prevent this behavior
