### PR TITLE
Fix on vert_attr_array

### DIFF
--- a/docs/beginner/tutorial4-buffer/README.md
+++ b/docs/beginner/tutorial4-buffer/README.md
@@ -182,7 +182,7 @@ Specifying the attributes as we did now is quite verbose. We could use the `vert
 wgpu::VertexBufferLayout {
     array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
     step_mode: wgpu::InputStepMode::Vertex,
-    attributes: &wgpu::vertex_attr_array![0 => Float32, 1 => Float32],
+    attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3],
 }
 ```
 


### PR DESCRIPTION
Note: I tried putting the lifetime to 'static but it didn't work. The solution was to put the result of the macro in a constant and then passing this constant to the `attributes` field