### PR TITLE
Fix camera uniform type

### DIFF
--- a/docs/beginner/tutorial6-uniforms/README.md
+++ b/docs/beginner/tutorial6-uniforms/README.md
@@ -234,7 +234,7 @@ struct CameraUniform {
     view_proj: mat4x4<f32>;
 };
 [[group(1), binding(0)]] // 2.
-var<uniform> camera: Camera;
+var<uniform> camera: CameraUniform;
 
 struct VertexInput {
     [[location(0)]] position: vec3<f32>;

--- a/docs/beginner/tutorial6-uniforms/README.md
+++ b/docs/beginner/tutorial6-uniforms/README.md
@@ -230,11 +230,11 @@ Modify the vertex shader to include the following.
 // Vertex shader
 
 [[block]] // 1.
-struct CameraUniform {
+struct Camera {
     view_proj: mat4x4<f32>;
 };
 [[group(1), binding(0)]] // 2.
-var<uniform> camera: CameraUniform;
+var<uniform> camera: Camera;
 
 struct VertexInput {
     [[location(0)]] position: vec3<f32>;


### PR DESCRIPTION
Hi, 
First thanks for your work, I love it and it makes wgpu really approchable. While following the beginner tutorial about "Uniform buffer and 3d camera" I run into this error: 

```
[2021-09-06T11:27:29Z ERROR wgpu_core::device] Failed to parse WGSL code for Some("Shader"): unknown type: 'Camera'
[2021-09-06T11:27:29Z ERROR wgpu::backend::direct] wgpu error: Validation Error

    Caused by:
        In Device::create_shader_module
          note: label = `Shader`
        Failed to parse WGSL
```

I could fix it by modifying the first few lines of the shader from 

```wgsl
[[block]]
struct CameraUniform {
    view_proj: mat4x4<f32>;
};
[[group(1), binding(0)]]
var<uniform> camera: Camera;
```

to 

```wgsl
[[block]]
struct CameraUniform {
    view_proj: mat4x4<f32>;
};
[[group(1), binding(0)]]
var<uniform> camera: CameraUniform;
```