### PR TITLE
remove dereference operator (`*`) for `PhysicalSize`s

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -206,11 +206,11 @@ match event {
             // ...
 
             WindowEvent::Resized(physical_size) => {
-                state.resize(*physical_size);
+                state.resize(physical_size);
             }
             WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
                 // new_inner_size is &&mut so we have to dereference it twice
-                state.resize(**new_inner_size);
+                state.resize(*new_inner_size);
             }
             // ...
 }
@@ -251,10 +251,10 @@ event_loop.run(move |event, _, control_flow| {
                     ..
                 } => *control_flow = ControlFlow::Exit,
                 WindowEvent::Resized(physical_size) => {
-                    state.resize(*physical_size);
+                    state.resize(physical_size);
                 }
                 WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                    state.resize(**new_inner_size);
+                    state.resize(*new_inner_size);
                 }
                 _ => {}
             }


### PR DESCRIPTION
WindowEvent::Resized carries a `PhysicalSize<u32>` type which implements the `Copy` trait,
WindowEvent::ScaleFactorChanged carries a `&mut PhysicalSize<u32>` type also implements the `Copy` trait.

In this case, there is no reason for dereferencing `PhysicalSize<u32>` and dereferencing `&mut PhysicalSize<u32>` twice.