### PR TITLE
Add section on why env_logger is needed

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -20,6 +20,11 @@ pollster = "0.2"
 ## Using Rust's new resolver
 As of version 0.10, wgpu require's cargo's [newest feature resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2). As a result you must include `resolver = "2"` in either the `[package]` section of `Cargo.toml` if you are working on a single crate, or the `[workspace]` section of the root `Cargo.toml` in a workspace.
 
+## env_logger
+It is very important to enable logging via `env_logger::init();`.
+When wgpu hits any error it panics with a generic message, while logging the real error via the log crate.
+This means if you dont include `env_logger::init()` wgpu will fail silently, leaving you very confused!
+
 ## The code
 There's not much going on here yet, so I'm just going to post the code in full. Just paste this into your `main.rs` or equivalent.
 


### PR DESCRIPTION
I helped someone resolve an issue on the rust game dev discord where they didnt realize the env_logger was important so left it out and then didnt realize why wgpu was giving such useless errors.
This change should help prevent people from making this mistake in the future.

Happy to completely rephrase the paragraph as needed.