### PR TITLE
Fixed code snippet.

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -152,8 +152,6 @@ Now that we've configured our surface properly we can add these new fields at th
 
 ```rust
         Self {
-            instance,
-            adapter,
             surface,
             device,
             queue,


### PR DESCRIPTION
'instance' and 'adapter' are not defined (and not needed) in State.