### PR TITLE
Fixed issue with code example was not ported to 0.10.x

### DIFF
--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -65,6 +65,7 @@ queue.write_texture(
         texture: &diffuse_texture,
         mip_level: 0,
         origin: wgpu::Origin3d::ZERO,
+        aspect: wgpu::TextureAspect::All,
     },
     // The actual pixel data
     diffuse_rgba,


### PR DESCRIPTION
As I was studying your tutorial, I noticed a code snipped not being ported over.
After testing the different enum options only the one with `aspect: wgpu::TextureAspect::All` will compile, so here is the change.

Thank you for your hard work creating the tutorial.