### PR TITLE
Name shader entry points differently.

### DIFF
--- a/code/beginner/tutorial3-pipeline/src/challenge.rs
+++ b/code/beginner/tutorial3-pipeline/src/challenge.rs
@@ -72,12 +72,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial3-pipeline/src/challenge.wgsl
+++ b/code/beginner/tutorial3-pipeline/src/challenge.wgsl
@@ -6,7 +6,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     [[builtin(vertex_index)]] in_vertex_index: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -20,6 +20,6 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(in.position, 0.5, 1.0);
 }

--- a/code/beginner/tutorial3-pipeline/src/main.rs
+++ b/code/beginner/tutorial3-pipeline/src/main.rs
@@ -71,12 +71,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial3-pipeline/src/shader.wgsl
+++ b/code/beginner/tutorial3-pipeline/src/shader.wgsl
@@ -5,7 +5,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     [[builtin(vertex_index)]] in_vertex_index: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -18,6 +18,6 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(0.3, 0.2, 0.1, 1.0);
 }

--- a/code/beginner/tutorial4-buffer/src/challenge.rs
+++ b/code/beginner/tutorial4-buffer/src/challenge.rs
@@ -135,12 +135,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial4-buffer/src/main.rs
+++ b/code/beginner/tutorial4-buffer/src/main.rs
@@ -128,12 +128,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial4-buffer/src/shader.wgsl
+++ b/code/beginner/tutorial4-buffer/src/shader.wgsl
@@ -11,7 +11,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -23,6 +23,6 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(in.color, 1.0);
 }

--- a/code/beginner/tutorial5-textures/src/challenge.rs
+++ b/code/beginner/tutorial5-textures/src/challenge.rs
@@ -201,12 +201,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial5-textures/src/main.rs
+++ b/code/beginner/tutorial5-textures/src/main.rs
@@ -178,12 +178,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial5-textures/src/shader.wgsl
+++ b/code/beginner/tutorial5-textures/src/shader.wgsl
@@ -11,7 +11,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -28,6 +28,6 @@ var t_diffuse: texture_2d<f32>;
 var s_diffuse: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return textureSample(t_diffuse, s_diffuse, in.tex_coords);
 }

--- a/code/beginner/tutorial6-uniforms/src/challenge.rs
+++ b/code/beginner/tutorial6-uniforms/src/challenge.rs
@@ -388,12 +388,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial6-uniforms/src/main.rs
+++ b/code/beginner/tutorial6-uniforms/src/main.rs
@@ -372,12 +372,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial6-uniforms/src/shader.wgsl
+++ b/code/beginner/tutorial6-uniforms/src/shader.wgsl
@@ -18,7 +18,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -35,6 +35,6 @@ var t_diffuse: texture_2d<f32>;
 var s_diffuse: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return textureSample(t_diffuse, s_diffuse, in.tex_coords);
 }

--- a/code/beginner/tutorial7-instancing/src/challenge.rs
+++ b/code/beginner/tutorial7-instancing/src/challenge.rs
@@ -501,12 +501,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc(), InstanceRaw::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial7-instancing/src/main.rs
+++ b/code/beginner/tutorial7-instancing/src/main.rs
@@ -465,12 +465,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc(), InstanceRaw::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial7-instancing/src/shader.wgsl
+++ b/code/beginner/tutorial7-instancing/src/shader.wgsl
@@ -24,7 +24,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -48,6 +48,6 @@ var t_diffuse: texture_2d<f32>;
 var s_diffuse: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return textureSample(t_diffuse, s_diffuse, in.tex_coords);
 }

--- a/code/beginner/tutorial8-depth/src/challenge.rs
+++ b/code/beginner/tutorial8-depth/src/challenge.rs
@@ -378,12 +378,12 @@ impl DepthPass {
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial8-depth/src/challenge.wgsl
+++ b/code/beginner/tutorial8-depth/src/challenge.wgsl
@@ -11,7 +11,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -28,7 +28,7 @@ var t_shadow: texture_depth_2d;
 var s_shadow: sampler_comparison;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let near = 0.1;
     let far = 100.0;
     let depth = textureSampleCompare(t_shadow, s_shadow, in.tex_coords, in.clip_position.w);

--- a/code/beginner/tutorial8-depth/src/main.rs
+++ b/code/beginner/tutorial8-depth/src/main.rs
@@ -478,12 +478,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[Vertex::desc(), InstanceRaw::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial8-depth/src/shader.wgsl
+++ b/code/beginner/tutorial8-depth/src/shader.wgsl
@@ -24,7 +24,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -48,6 +48,6 @@ var t_diffuse: texture_2d<f32>;
 var s_diffuse: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return textureSample(t_diffuse, s_diffuse, in.tex_coords);
 }

--- a/code/beginner/tutorial9-models/src/main.rs
+++ b/code/beginner/tutorial9-models/src/main.rs
@@ -406,12 +406,12 @@ impl State {
             layout: Some(&render_pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "vs_main",
                 buffers: &[model::ModelVertex::desc(), InstanceRaw::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "main",
+                entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: config.format,
                     blend: Some(wgpu::BlendState {

--- a/code/beginner/tutorial9-models/src/shader.wgsl
+++ b/code/beginner/tutorial9-models/src/shader.wgsl
@@ -24,7 +24,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -48,6 +48,6 @@ var t_diffuse: texture_2d<f32>;
 var s_diffuse: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return textureSample(t_diffuse, s_diffuse, in.tex_coords);
 }

--- a/code/intermediate/tutorial10-lighting/src/light.wgsl
+++ b/code/intermediate/tutorial10-lighting/src/light.wgsl
@@ -26,7 +26,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     let scale = 0.25;
@@ -39,6 +39,6 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(in.color, 1.0);
 }

--- a/code/intermediate/tutorial10-lighting/src/main.rs
+++ b/code/intermediate/tutorial10-lighting/src/main.rs
@@ -287,12 +287,12 @@ fn create_render_pipeline(
         layout: Some(layout),
         vertex: wgpu::VertexState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "vs_main",
             buffers: vertex_layouts,
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "fs_main",
             targets: &[wgpu::ColorTargetState {
                 format: color_format,
                 blend: Some(wgpu::BlendState {

--- a/code/intermediate/tutorial10-lighting/src/shader.wgsl
+++ b/code/intermediate/tutorial10-lighting/src/shader.wgsl
@@ -39,7 +39,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -71,7 +71,7 @@ var t_diffuse: texture_2d<f32>;
 var s_diffuse: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let object_color: vec4<f32> = textureSample(t_diffuse, s_diffuse, in.tex_coords);
     
     // We don't need (or want) much ambient light, so 0.1 is fine

--- a/code/intermediate/tutorial11-normals/src/light.wgsl
+++ b/code/intermediate/tutorial11-normals/src/light.wgsl
@@ -26,7 +26,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     let scale = 0.25;
@@ -39,6 +39,6 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(in.color, 1.0);
 }

--- a/code/intermediate/tutorial11-normals/src/main.rs
+++ b/code/intermediate/tutorial11-normals/src/main.rs
@@ -288,12 +288,12 @@ fn create_render_pipeline(
         layout: Some(layout),
         vertex: wgpu::VertexState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "vs_main",
             buffers: vertex_layouts,
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "fs_main",
             targets: &[wgpu::ColorTargetState {
                 format: color_format,
                 blend: Some(wgpu::BlendState {

--- a/code/intermediate/tutorial11-normals/src/shader.wgsl
+++ b/code/intermediate/tutorial11-normals/src/shader.wgsl
@@ -42,7 +42,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -91,7 +91,7 @@ var t_normal: texture_2d<f32>;
 var s_normal: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let object_color: vec4<f32> = textureSample(t_diffuse, s_diffuse, in.tex_coords);
     let object_normal: vec4<f32> = textureSample(t_normal, s_normal, in.tex_coords);
     

--- a/code/intermediate/tutorial12-camera/src/light.wgsl
+++ b/code/intermediate/tutorial12-camera/src/light.wgsl
@@ -26,7 +26,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     let scale = 0.25;
@@ -39,6 +39,6 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(in.color, 1.0);
 }

--- a/code/intermediate/tutorial12-camera/src/main.rs
+++ b/code/intermediate/tutorial12-camera/src/main.rs
@@ -168,12 +168,12 @@ fn create_render_pipeline(
         layout: Some(layout),
         vertex: wgpu::VertexState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "vs_main",
             buffers: vertex_layouts,
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "fs_main",
             targets: &[wgpu::ColorTargetState {
                 format: color_format,
                 blend: Some(wgpu::BlendState {

--- a/code/intermediate/tutorial12-camera/src/shader.wgsl
+++ b/code/intermediate/tutorial12-camera/src/shader.wgsl
@@ -42,7 +42,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -91,7 +91,7 @@ var t_normal: texture_2d<f32>;
 var s_normal: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let object_color: vec4<f32> = textureSample(t_diffuse, s_diffuse, in.tex_coords);
     let object_normal: vec4<f32> = textureSample(t_normal, s_normal, in.tex_coords);
     

--- a/code/intermediate/tutorial13-threading/src/light.wgsl
+++ b/code/intermediate/tutorial13-threading/src/light.wgsl
@@ -26,7 +26,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     let scale = 0.25;
@@ -39,6 +39,6 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(in.color, 1.0);
 }

--- a/code/intermediate/tutorial13-threading/src/main.rs
+++ b/code/intermediate/tutorial13-threading/src/main.rs
@@ -167,12 +167,12 @@ fn create_render_pipeline(
         layout: Some(layout),
         vertex: wgpu::VertexState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "vs_main",
             buffers: vertex_layouts,
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "fs_main",
             targets: &[wgpu::ColorTargetState {
                 format: color_format,
                 blend: Some(wgpu::BlendState {

--- a/code/intermediate/tutorial13-threading/src/shader.wgsl
+++ b/code/intermediate/tutorial13-threading/src/shader.wgsl
@@ -42,7 +42,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -91,7 +91,7 @@ var t_normal: texture_2d<f32>;
 var s_normal: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let object_color: vec4<f32> = textureSample(t_diffuse, s_diffuse, in.tex_coords);
     let object_normal: vec4<f32> = textureSample(t_normal, s_normal, in.tex_coords);
     

--- a/docs/beginner/tutorial3-pipeline/README.md
+++ b/docs/beginner/tutorial3-pipeline/README.md
@@ -46,7 +46,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     [[builtin(vertex_index)]] in_vertex_index: u32,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -65,7 +65,7 @@ Vector types such as `vec4` are generic. Currently you must specify the type of 
 
 </div>
 
-The next part of the shader code is the `main` function. We are using `[[stage(vertex)]]` to mark this function as a valid entry point for a vertex shader. We expect a `u32` called `in_vertex_index` which gets its value from `[[builtin(vertex_index)]]`.
+The next part of the shader code is the `vs_main` function. We are using `[[stage(vertex)]]` to mark this function as a valid entry point for a vertex shader. We expect a `u32` called `in_vertex_index` which gets its value from `[[builtin(vertex_index)]]`.
 
 We then declare a variable called `out` using our `VertexOutput` struct. We create two other variables for the `x`, and `y`, of a triangle.
 
@@ -89,7 +89,7 @@ We technically didn't need a struct for this example, and could have just done s
 
 ```wgsl
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     [[builtin(vertex_index)]] in_vertex_index: u32
 ) -> [[builtin(position)]] vec4<f32> {
     // Vertex shader code...
@@ -106,7 +106,7 @@ Next up the fragment shader. Still in `shader.wgsl` add the follow:
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(0.3, 0.2, 0.1, 1.0);
 }
 ```
@@ -115,7 +115,7 @@ All this does is set the color of the current fragment to brown color.
 
 <div class="note">
 
-Notice that this function is also called `main`. Because this function is marked as a fragment shader entry point, this is ok. You can change the names around if you like, but I've opted to keep them the same.
+Notice that the entry point for the vertex shader was named `vs_main` and that the entry point for the fragment shader is called `fs_main`. In earlier versions of wgpu it was ok to both name these functions the same, but newer versions of the [WGSL spec](https://www.w3.org/TR/WGSL/#declaration-and-scope) require these names to be different. Therefore the above mentioned naming scheme (which is adopted from the `wgpu` examples) is used throughout the tutorial.
 
 </div>
 
@@ -165,12 +165,12 @@ let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescrip
     layout: Some(&render_pipeline_layout),
     vertex: wgpu::VertexState {
         module: &shader,
-        entry_point: "main", // 1.
+        entry_point: "vs_main", // 1.
         buffers: &[], // 2.
     },
     fragment: Some(wgpu::FragmentState { // 3.
         module: &shader,
-        entry_point: "main",
+        entry_point: "fs_main",
         targets: &[wgpu::ColorTargetState { // 4.
             format: config.format,
             blend: Some(wgpu::BlendState::REPLACE),

--- a/docs/beginner/tutorial4-buffer/README.md
+++ b/docs/beginner/tutorial4-buffer/README.md
@@ -273,7 +273,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -285,7 +285,7 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(in.color, 1.0);
 }
 ```

--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -366,7 +366,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;
@@ -387,7 +387,7 @@ var t_diffuse: texture_2d<f32>;
 var s_diffuse: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return textureSample(t_diffuse, s_diffuse, in.tex_coords);
 }
 ```

--- a/docs/beginner/tutorial6-uniforms/README.md
+++ b/docs/beginner/tutorial6-uniforms/README.md
@@ -247,7 +247,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     var out: VertexOutput;

--- a/docs/beginner/tutorial7-instancing/README.md
+++ b/docs/beginner/tutorial7-instancing/README.md
@@ -233,7 +233,7 @@ We need to reassemble the matrix before we can use it.
 
 ```wgsl
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -251,7 +251,7 @@ We'll apply the `model_matrix` before we apply `camera_uniform.view_proj`. We do
 
 ```wgsl
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {

--- a/docs/intermediate/tutorial10-lighting/README.md
+++ b/docs/intermediate/tutorial10-lighting/README.md
@@ -125,12 +125,12 @@ fn create_render_pipeline(
         layout: Some(layout),
         vertex: wgpu::VertexState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "vs_main",
             buffers: vertex_layouts,
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
-            entry_point: "main",
+            entry_point: "fs_main",
             targets: &[wgpu::ColorTargetState {
                 format: color_format,
                 blend: Some(wgpu::BlendState {
@@ -334,7 +334,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
     let scale = 0.25;
@@ -347,7 +347,7 @@ fn main(
 // Fragment shader
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     return vec4<f32>(in.color, 1.0);
 }
 ```
@@ -485,7 +485,7 @@ Then we need to update our main shader code to calculate and use the ambient col
 
 ```wgsl
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let object_color: vec4<f32> = textureSample(t_diffuse, s_diffuse, in.tex_coords);
     
     // We don't need (or want) much ambient light, so 0.1 is fine
@@ -535,7 +535,7 @@ For now let's just pass the normal directly as is. This is wrong, but we'll fix 
 
 ```wgsl
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -719,7 +719,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {

--- a/docs/intermediate/tutorial11-normals/README.md
+++ b/docs/intermediate/tutorial11-normals/README.md
@@ -111,7 +111,7 @@ var t_normal: texture_2d<f32>;
 var s_normal: sampler;
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let object_color: vec4<f32> = textureSample(t_diffuse, s_diffuse, in.tex_coords);
     let object_normal: vec4<f32> = textureSample(t_normal, s_normal, in.tex_coords);
     
@@ -345,7 +345,7 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(
+fn vs_main(
     model: VertexInput,
     instance: InstanceInput,
 ) -> VertexOutput {
@@ -382,7 +382,7 @@ Finally we'll update the fragment shader to use these transformed lighting value
 
 ```wgsl
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     // Sample textures..
 
     // Create the lighting vectors


### PR DESCRIPTION
Fixes #255.

I renamed the shader entrypoints to
- `vs_main` for the vertex shader
- `fs_main` for the fragment shader

This is the same naming convention, that is used in the [wgpu examples](https://github.com/gfx-rs/wgpu/blob/e7aeb4c2187609e1f21c6cebb354c02fab406851/wgpu/examples/cube/shader.wgsl#L14). This was actually the reason for https://github.com/FrankenApps/wgpu_cube/issues/2#issuecomment-946911550 so I decided to make this PR to prevent confusion in the future.

I tried to catch all appearances and also updated the docs, but a second look wouldn't hurt, in particular I was not sure how to
- deal with the `.frag`, `.vert` and `.spv` shaders since they are currently not really in use (I did not make any changes to these)
- deal with the showcase examples (mainly because those for the most part do not use `wgsl` yet; I also did not make any changes there)