### PR TITLE
Typo: TextureUsages::OUTPUT_ATTACHMENT

### DIFF
--- a/docs/showcase/windowless/README.md
+++ b/docs/showcase/windowless/README.md
@@ -46,7 +46,7 @@ let texture = device.create_texture(&texture_desc);
 let texture_view = texture.create_view(&Default::default());
 ```
 
-We're using `TextureUsages::OUTPUT_ATTACHMENT` so wgpu can render to our texture. The `TextureUsages::COPY_SRC` is so we can pull data out of the texture so we can save it to a file.
+We're using `TextureUsages::RENDER_ATTACHMENT` so wgpu can render to our texture. The `TextureUsages::COPY_SRC` is so we can pull data out of the texture so we can save it to a file.
 
 While we can use this texture to draw our triangle, we need some way to get at the pixels inside it. Back in the [texture tutorial](/beginner/tutorial5-textures/) we used a buffer load color data from a file that we then copied into our buffer. Now we are going to do the reverse: copy data into a buffer from our texture to save into a file. We'll need a buffer big enough for our data.
 


### PR DESCRIPTION
TextureUsages::OUTPUT_ATTACHMENT doesn't exist. Changing to TextureUsages::RENDER_ATTACHMENT, which is what the code example uses.