### PR TITLE
Fixed flipped tex_coords in tutorial5-textures

### DIFF
--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -303,9 +303,8 @@ First, we'll change the `Vertex` struct:
 ```rust
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
-struct Vertex {
-    position: [f32; 3],
-    tex_coords: [f32; 2], // NEW!
+struct Vertex  position: [f32; 3],
+    tex ords: [f32; 2],   NEW!
 }
 ```
 
@@ -340,11 +339,11 @@ Lastly we need to change `VERTICES` itself. Replace the existing definition with
 ```rust
 // Changed
 const VERTICES: &[Vertex] = &[
-    Vertex { position: [-0.0868241, 0.49240386, 0.0], tex_coords: [0.4131759, 0.99240386], }, // A
-    Vertex { position: [-0.49513406, 0.06958647, 0.0], tex_coords: [0.0048659444, 0.56958646], }, // B
-    Vertex { position: [-0.21918549, -0.44939706, 0.0], tex_coords: [0.28081453, 0.050602943], }, // C
-    Vertex { position: [0.35966998, -0.3473291, 0.0], tex_coords: [0.85967, 0.15267089], }, // D
-    Vertex { position: [0.44147372, 0.2347359, 0.0], tex_coords: [0.9414737, 0.7347359], }, // E
+    Vertex { position: [-0.0868241, 0.49240386, 0.0], tex_coords: [0.4131759, 0.00759614], }, // A
+    Vertex { position: [-0.49513406, 0.06958647, 0.0], tex_coords: [0.0048659444, 0.43041354], }, // B
+    Vertex { position: [-0.21918549, -0.44939706, 0.0], tex_coords: [0.28081453, 0.949397], }, // C
+    Vertex { position: [0.35966998, -0.3473291, 0.0], tex_coords: [0.85967, 0.84732914], }, // D
+    Vertex { position: [0.44147372, 0.2347359, 0.0], tex_coords: [0.9414737, 0.2652641], }, // E
 ];
 ```
 

--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -303,8 +303,9 @@ First, we'll change the `Vertex` struct:
 ```rust
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
-struct Vertex  position: [f32; 3],
-    tex ords: [f32; 2],   NEW!
+struct Vertex {
+    position: [f32; 3],
+    tex_coords: [f32; 2], // NEW!
 }
 ```
 


### PR DESCRIPTION
The `VERTICES` listed in the tutorial were using the old Y values for `tex_coords` which made the texture appear upside down.