### PR TITLE
Fix old field name

### DIFF
--- a/docs/beginner/tutorial4-buffer/README.md
+++ b/docs/beginner/tutorial4-buffer/README.md
@@ -32,7 +32,7 @@ const VERTICES: &[Vertex] = &[
 ];
 ```
 
-We arrange the vertices in counter-clockwise order: top, bottom left, bottom right. We do it this way partially out of tradition, but mostly because we specified in the `rasterization_state` of the `render_pipeline` that we want the `front_face` of our triangle to be `wgpu::FrontFace::Ccw` so that we cull the back face. This means that any triangle that should be facing us should have its vertices in counter-clockwise order.
+We arrange the vertices in counter-clockwise order: top, bottom left, bottom right. We do it this way partially out of tradition, but mostly because we specified in the `primitive` of the `render_pipeline` that we want the `front_face` of our triangle to be `wgpu::FrontFace::Ccw` so that we cull the back face. This means that any triangle that should be facing us should have its vertices in counter-clockwise order.
 
 Now that we have our vertex data, we need to store it in a buffer. Let's add a `vertex_buffer` field to `State`.
 


### PR DESCRIPTION
`rasterization_state` is an old field name of `wgpu::RenderPipelineDescriptor` (I could find it in wgpu v0.4.0). This PR fixes it to `primitive`.