### PR TITLE
Fix `wgpu::SamplerBindingType` is now parameter of `wgpu::BindingType::Sampler`

### DIFF
--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -181,14 +181,13 @@ let texture_bind_group_layout = device.create_bind_group_layout(
             wgpu::BindGroupLayoutEntry {
                 binding: 1,
                 visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler {
-                    // This is only for TextureSampleType::Depth
-                    comparison: false,
-                    // This should be true if the sample_type of the texture is:
+                ty: wgpu::BindingType::Sampler(
+                    // SamplerBindingType::Comparison is only for TextureSampleType::Depth
+                    // SamplerBindingType::Filtering if the sample_type of the texture is:
                     //     TextureSampleType::Float { filterable: true }
                     // Otherwise you'll get an error.
-                    filtering: true,
-                },
+                    wgpu::SamplerBindingType::Filtering,
+                ),
                 count: None,
             },
         ],


### PR DESCRIPTION
[`wgpu::BindingType::Sampler`](https://docs.rs/wgpu/latest/wgpu/enum.BindingType.html) now takes [`wgpu::SamplerBindingType`](https://docs.rs/wgpu/latest/wgpu/enum.SamplerBindingType.html) enum for specific type of a sampler binding. Sample code had already been corrected, but the document was not corrected yet.