### PR TITLE
Fix to Link to the "alignment" page

### DIFF
--- a/docs/showcase/compute/README.md
+++ b/docs/showcase/compute/README.md
@@ -26,7 +26,7 @@ struct ModelVertex {
 };
 ```
 
-At first glance, this seems just fine, but OpenGL experts would likely see a problem with the structure. Our fields aren't aligned properly to support the `std430` alignment that storage buffers require.. I won't get into detail but you can check out the [alignment showcase](/showcase/alignment) if you want to know more. To summarize, the `vec2` for the `tex_coords` was messing up the byte alignment, corrupting the vertex data resulting in the following:
+At first glance, this seems just fine, but OpenGL experts would likely see a problem with the structure. Our fields aren't aligned properly to support the `std430` alignment that storage buffers require.. I won't get into detail but you can check out the [alignment showcase](../alignment) if you want to know more. To summarize, the `vec2` for the `tex_coords` was messing up the byte alignment, corrupting the vertex data resulting in the following:
 
 ![./corruption.png](./corruption.png)
 


### PR DESCRIPTION
Fix to [Link to the "alignment" page is broken #291](https://github.com/sotrh/learn-wgpu/issues/291#issue-1092108325) issue.
In a rather counterintuitive way for me the link is broken, after a few random attempts this modification allows you to make it visitable.