### PR TITLE
Mention include_wgsl!

### DIFF
--- a/docs/beginner/tutorial3-pipeline/README.md
+++ b/docs/beginner/tutorial3-pipeline/README.md
@@ -146,6 +146,17 @@ let shader = device.create_shader_module(&wgpu::ShaderModuleDescriptor {
 });
 ```
 
+<div class="note">
+
+You can also use `include_wgsl!` macro as a small shortcut to create the `ShaderModuleDescriptor`.
+
+```rust
+let shader = device.create_shader_module(&include_wgsl!("shader.wgsl"));
+```
+
+</div>
+
+
 One more thing, we need to create a `PipelineLayout`. We'll get more into this after we cover `Buffer`s.
 
 ```rust


### PR DESCRIPTION
I guess it's your preference not to use such a shortcut for the sake of education, but I think `include_wgsl!` should be mentioned at least. `include_wgsl!` is already used in the code of the showcases.