### PR TITLE
Remove is_{up,down}_pressed

### DIFF
--- a/code/beginner/tutorial6-uniforms/src/challenge.rs
+++ b/code/beginner/tutorial6-uniforms/src/challenge.rs
@@ -126,8 +126,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -138,8 +136,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -160,14 +156,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/code/beginner/tutorial6-uniforms/src/main.rs
+++ b/code/beginner/tutorial6-uniforms/src/main.rs
@@ -110,8 +110,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -122,8 +120,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -144,14 +140,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/code/beginner/tutorial7-instancing/src/challenge.rs
+++ b/code/beginner/tutorial7-instancing/src/challenge.rs
@@ -117,8 +117,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -129,8 +127,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -151,14 +147,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/code/beginner/tutorial7-instancing/src/main.rs
+++ b/code/beginner/tutorial7-instancing/src/main.rs
@@ -117,8 +117,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -129,8 +127,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -151,14 +147,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/code/beginner/tutorial8-depth/src/challenge.rs
+++ b/code/beginner/tutorial8-depth/src/challenge.rs
@@ -140,8 +140,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -152,8 +150,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -174,14 +170,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/code/beginner/tutorial8-depth/src/main.rs
+++ b/code/beginner/tutorial8-depth/src/main.rs
@@ -117,8 +117,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -129,8 +127,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -151,14 +147,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/code/beginner/tutorial9-models/src/main.rs
+++ b/code/beginner/tutorial9-models/src/main.rs
@@ -61,8 +61,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -73,8 +71,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -95,14 +91,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/code/intermediate/tutorial10-lighting/src/main.rs
+++ b/code/intermediate/tutorial10-lighting/src/main.rs
@@ -65,8 +65,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -77,8 +75,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -99,14 +95,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/code/intermediate/tutorial11-normals/src/main.rs
+++ b/code/intermediate/tutorial11-normals/src/main.rs
@@ -64,8 +64,6 @@ impl CameraUniform {
 
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -76,8 +74,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -98,14 +94,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true

--- a/docs/beginner/tutorial6-uniforms/README.md
+++ b/docs/beginner/tutorial6-uniforms/README.md
@@ -271,8 +271,6 @@ The shape's less stretched now, but it's still pretty static. You can experiment
 ```rust
 struct CameraController {
     speed: f32,
-    is_up_pressed: bool,
-    is_down_pressed: bool,
     is_forward_pressed: bool,
     is_backward_pressed: bool,
     is_left_pressed: bool,
@@ -283,8 +281,6 @@ impl CameraController {
     fn new(speed: f32) -> Self {
         Self {
             speed,
-            is_up_pressed: false,
-            is_down_pressed: false,
             is_forward_pressed: false,
             is_backward_pressed: false,
             is_left_pressed: false,
@@ -304,14 +300,6 @@ impl CameraController {
             } => {
                 let is_pressed = *state == ElementState::Pressed;
                 match keycode {
-                    VirtualKeyCode::Space => {
-                        self.is_up_pressed = is_pressed;
-                        true
-                    }
-                    VirtualKeyCode::LShift => {
-                        self.is_down_pressed = is_pressed;
-                        true
-                    }
                     VirtualKeyCode::W | VirtualKeyCode::Up => {
                         self.is_forward_pressed = is_pressed;
                         true
@@ -352,7 +340,7 @@ impl CameraController {
 
         let right = forward_norm.cross(camera.up);
 
-        // Redo radius calc in case the up/ down is pressed.
+        // Redo radius calc in case the fowrard/backward is pressed.
         let forward = camera.target - camera.eye;
         let forward_mag = forward.magnitude();
 


### PR DESCRIPTION
Fix #300 

These variables are stored but never used in actual. As you commented on #300, it might be great if there's also these controls, but these are not what we cannot live without. Considering the purpose of the tutorials, probably it's a good idea to remove them to avoid confusion, at least for now.