### PR TITLE
tut6: remove sentence about block decorator

### DIFF
--- a/docs/beginner/tutorial6-uniforms/README.md
+++ b/docs/beginner/tutorial6-uniforms/README.md
@@ -228,11 +228,10 @@ Modify the vertex shader to include the following.
 
 ```wgsl
 // Vertex shader
- // 1.
 struct CameraUniform {
     view_proj: mat4x4<f32>;
 };
-[[group(1), binding(0)]] // 2.
+[[group(1), binding(0)]] // 1.
 var<uniform> camera: CameraUniform;
 
 struct VertexInput {
@@ -251,14 +250,13 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
     out.tex_coords = model.tex_coords;
-    out.clip_position = camera.view_proj * vec4<f32>(model.position, 1.0); // 3.
+    out.clip_position = camera.view_proj * vec4<f32>(model.position, 1.0); // 2.
     return out;
 }
 ```
 
-1. According to the [WGSL Spec](https://gpuweb.github.io/gpuweb/wgsl/), The block decorator indicates this structure type represents the contents of a buffer resource occupying a single binding slot in the shader’s resource interface. Any structure used as a `uniform` must be annotated with `[[block]]`
-2. Because we've created a new bind group, we need to specify which one we're using in the shader. The number is determined by our `render_pipeline_layout`. The `texture_bind_group_layout` is listed first, thus it's `group(0)`, and `camera_bind_group` is second, so it's `group(1)`.
-3. Multiplication order is important when it comes to matrices. The vector goes on the right, and the matrices gone on the left in order of importance.
+1. Because we've created a new bind group, we need to specify which one we're using in the shader. The number is determined by our `render_pipeline_layout`. The `texture_bind_group_layout` is listed first, thus it's `group(0)`, and `camera_bind_group` is second, so it's `group(1)`.
+2. Multiplication order is important when it comes to matrices. The vector goes on the right, and the matrices gone on the left in order of importance.
 
 ## A controller for our camera
 


### PR DESCRIPTION
This PR removes a note about the `[[block]]` decorator which is no longer needed (as mentioned in [the news page section](https://github.com/sotrh/learn-wgpu/blob/4d0be61d76d156db8c8f1a6a2b97ea70b5506ec8/docs/news/0.12/readme.md?plain=1#L12) added by 7a42a0d4db1fa17121d5f7b285d5e6ca865b65a2).

I was very confused for some time trying to figure out what this sentence was referring to, and I think it can be removed, since it is no longer in the WGSL spec.