### PR TITLE
Correct an error in the normal map tutorial

### DIFF
--- a/docs/intermediate/tutorial11-normals/README.md
+++ b/docs/intermediate/tutorial11-normals/README.md
@@ -41,10 +41,7 @@ let texture_bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroup
         wgpu::BindGroupLayoutEntry {
             binding: 3,
             visibility: wgpu::ShaderStages::FRAGMENT,
-            ty: wgpu::BindingType::Sampler { 
-                comparison: false,
-                filtering: true, 
-            },
+            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
             count: None,
         },
     ],


### PR DESCRIPTION
`wgpu::BindingType::Sampler` is a tuple like variant in wgpu 0.12