### PR TITLE
Add missing half_dir

### DIFF
--- a/docs/intermediate/tutorial11-normals/README.md
+++ b/docs/intermediate/tutorial11-normals/README.md
@@ -123,6 +123,7 @@ fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let tangent_normal = object_normal.xyz * 2.0 - 1.0;
     let light_dir = normalize(light.position - in.world_position);
     let view_dir = normalize(camera.view_pos.xyz - in.world_position);
+    let half_dir = normalize(view_dir + light_dir);
 
     let diffuse_strength = max(dot(tangent_normal, light_dir), 0.0);
     let diffuse_color = light.color * diffuse_strength;


### PR DESCRIPTION
The shader panics (see below) because `half_dir` is missing so I added it.
```
❯ cargo run
   Compiling graphic_rust v0.1.0 (/home/rokonio/dev/rust/graphic_rust)
    Finished dev [unoptimized + debuginfo] target(s) in 5.39s
     Running `target/debug/graphic_rust`
[2022-02-20T10:27:50Z ERROR wgpu::backend::direct] Handling wgpu errors as fatal by default
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_shader_module
      note: label = `Shader`
    
Shader 'Shader' parsing error: no definition in scope for identifier: 'half_dir'
   ┌─ wgsl:93:57
   │
93 │     let specular_strength = pow(max(dot(tangent_normal, half_dir), 0.0), 32.0);
   │                                                         ^^^^^^^^ unknown identifier


    no definition in scope for identifier: 'half_dir'

', /home/rokonio/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.12.0/src/backend/direct.rs:2273:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```