### PR TITLE
fix tobj version

### DIFF
--- a/docs/beginner/tutorial9-models/README.md
+++ b/docs/beginner/tutorial9-models/README.md
@@ -231,7 +231,9 @@ We're going to use the [tobj](https://docs.rs/tobj/3.0/tobj/) library to load ou
 ```toml
 [dependencies]
 # other dependencies...
-tobj = "3.0"
+tobj = { version = "3.2.1", features = [
+    "async",
+]}
 ```
 
 Before we can load our model though, we need somewhere to put it.


### PR DESCRIPTION
This PR is required to use `tobj::load_model_buf_async`.

https://github.com/Twinklebear/tobj/releases/tag/3.2.0