### PR TITLE
Add pollster and cfg-if to dependencies

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -8,6 +8,7 @@ For the beginner stuff, we're going to keep things very simple, we'll add things
 
 ```toml
 [dependencies]
+cfg-if = "1"
 winit = "0.26"
 env_logger = "0.9"
 log = "0.4"

--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -12,6 +12,7 @@ winit = "0.26"
 env_logger = "0.9"
 log = "0.4"
 wgpu = "0.12"
+pollster = "0.2"
 ```
 
 ## Using Rust's new resolver


### PR DESCRIPTION
Thanks for the nice tutorial.

I noticed that pollster and cfg-if is missing as a dependency in the docs. 
Probably not a big issue as it is easily resolved, but might cause issues when copy & pasting the dependencies from the tutorial. 