### PR TITLE
Fix indentation

### DIFF
--- a/code/beginner/tutorial9-models/src/resources.rs
+++ b/code/beginner/tutorial9-models/src/resources.rs
@@ -6,14 +6,15 @@ use wgpu::util::DeviceExt;
 use crate::{model, texture};
 
 #[cfg(target_arch = "wasm32")]
-    fn format_url(file_name: &str) -> reqwest::Url {
+fn format_url(file_name: &str) -> reqwest::Url {
     let window = web_sys::window().unwrap();
     let location = window.location();
     let base = reqwest::Url::parse(&format!(
         "{}/{}/",
         location.origin().unwrap(),
         option_env!("RES_PATH").unwrap_or("res"),
-    )).unwrap();
+    ))
+    .unwrap();
     base.join(file_name).unwrap()
 }
 

--- a/code/intermediate/tutorial10-lighting/src/resources.rs
+++ b/code/intermediate/tutorial10-lighting/src/resources.rs
@@ -6,7 +6,7 @@ use wgpu::util::DeviceExt;
 use crate::{model, texture};
 
 #[cfg(target_arch = "wasm32")]
-    fn format_url(file_name: &str) -> reqwest::Url {
+fn format_url(file_name: &str) -> reqwest::Url {
     let window = web_sys::window().unwrap();
     let location = window.location();
     let base = reqwest::Url::parse(&format!(

--- a/code/intermediate/tutorial11-normals/src/resources.rs
+++ b/code/intermediate/tutorial11-normals/src/resources.rs
@@ -6,14 +6,15 @@ use wgpu::util::DeviceExt;
 use crate::{model, texture};
 
 #[cfg(target_arch = "wasm32")]
-    fn format_url(file_name: &str) -> reqwest::Url {
+fn format_url(file_name: &str) -> reqwest::Url {
     let window = web_sys::window().unwrap();
     let location = window.location();
     let base = reqwest::Url::parse(&format!(
         "{}/{}/",
         location.origin().unwrap(),
         option_env!("RES_PATH").unwrap_or("res"),
-    )).unwrap();
+    ))
+    .unwrap();
     base.join(file_name).unwrap()
 }
 

--- a/code/intermediate/tutorial12-camera/src/resources.rs
+++ b/code/intermediate/tutorial12-camera/src/resources.rs
@@ -6,7 +6,7 @@ use wgpu::util::DeviceExt;
 use crate::{model, texture};
 
 #[cfg(target_arch = "wasm32")]
-    fn format_url(file_name: &str) -> reqwest::Url {
+fn format_url(file_name: &str) -> reqwest::Url {
     let window = web_sys::window().unwrap();
     let location = window.location();
     let base = reqwest::Url::parse(&format!(

--- a/docs/beginner/tutorial9-models/README.md
+++ b/docs/beginner/tutorial9-models/README.md
@@ -142,7 +142,7 @@ use wgpu::util::DeviceExt;
 use crate::{model, texture};
 
 #[cfg(target_arch = "wasm32")]
-    fn format_url(file_name: &str) -> reqwest::Url {
+fn format_url(file_name: &str) -> reqwest::Url {
     let window = web_sys::window().unwrap();
     let location = window.location();
     let base = reqwest::Url::parse(&format!(


### PR DESCRIPTION
Removes some unnecessary indentation, visible in the 'Model Loading' chapter but also appearing in other code files.  There's some other minor formatting adjustments from `rustfmt`, but these are nearly negligible.