### PR TITLE
Removed "pollster" from tutorial1-window readme.

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -66,7 +66,7 @@ All this does is create a window, and keep it open until the user closes it, or 
 use tutorial1_window::run;
 
 fn main() {
-    pollster::block_on(run());
+    run();
 }
 ```
 


### PR DESCRIPTION
It seems that in #345 pollster was removed from the example, but not from the code in the page.
This change removes it from the code in the tutorial, so it will work just by pasting it in the editor.