### PR TITLE
fix: point code snippet to right file name

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -4,7 +4,7 @@
 For convenience, we're going to pack all the fields into a struct and create some methods on that.
 
 ```rust
-// main.rs
+// lib.rs
 use winit::window::Window;
 
 struct State {


### PR DESCRIPTION
Minor error, at starting of [The Surface](https://sotrh.github.io/learn-wgpu/beginner/tutorial2-surface/#first-some-housekeeping-state), the code snippets points to `main.rs` while its code actually belongs to `libs.rs`.