### PR TITLE
Remove incorrect .unwrap()

### DIFF
--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -35,7 +35,7 @@ surface.configure(&device, &config);
 
 let diffuse_bytes = include_bytes!("happy-tree.png");
 let diffuse_image = image::load_from_memory(diffuse_bytes).unwrap();
-let diffuse_rgba = diffuse_image.to_rgba8().unwrap();
+let diffuse_rgba = diffuse_image.to_rgba8();
 
 use image::GenericImageView;
 let dimensions = diffuse_image.dimensions();


### PR DESCRIPTION
This line used to say `diffuse_image.as_rgba8().unwrap();`, which got changed to `diffuse_image.to_rgba8().unwrap();` in b8b84440303c486d76d252977cea5d8b8e771aef.
Because `to_rgba()` does not return an `Option` like `as_rgba()`, the `.unwrap()` causes an error.