### PR TITLE
fix: typo in write_texture

### DIFF
--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -83,7 +83,7 @@ queue.write_texture(
         aspect: wgpu::TextureAspect::All,
     },
     // The actual pixel data
-    diffuse_rgba,
+    &diffuse_rgba,
     // The layout of the texture
     wgpu::ImageDataLayout {
         offset: 0,


### PR DESCRIPTION
missing reference