### PR TITLE
Fixed missing `pub` in ModelVertex struct

### DIFF
--- a/docs/beginner/tutorial9-models/README.md
+++ b/docs/beginner/tutorial9-models/README.md
@@ -13,9 +13,9 @@ pub trait Vertex {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct ModelVertex {
-    position: [f32; 3],
-    tex_coords: [f32; 2],
-    normal: [f32; 3],
+    pub position: [f32; 3],
+    pub tex_coords: [f32; 2],
+    pub normal: [f32; 3],
 }
 
 impl Vertex for ModelVertex {


### PR DESCRIPTION
This causes an error when constructing the struct from `load_model` in resources.rs.
The fields are already `pub` in the code, but not in the docs:
https://github.com/sotrh/learn-wgpu/blob/bcb4282f1ef9e70fa88a518905c532625c38b255/code/beginner/tutorial9-models/src/model.rs#L11-L15