### PR TITLE
Replace main.rs with lib.rs in intermediate tutorials

### DIFF
--- a/docs/intermediate/tutorial10-lighting/README.md
+++ b/docs/intermediate/tutorial10-lighting/README.md
@@ -27,7 +27,7 @@ Ray/path tracing is often too computationally expensive for most real-time appli
 Before we can get into that though, we need to add a light to our scene.
 
 ```rust
-// main.rs
+// lib.rs
 #[repr(C)]
 #[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 struct LightUniform {
@@ -307,7 +307,7 @@ where
 With that done we can create another render pipeline for our light.
 
 ```rust
-// main.rs
+// lib.rs
 let light_render_pipeline = {
     let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("Light Pipeline Layout"),

--- a/docs/intermediate/tutorial11-normals/README.md
+++ b/docs/intermediate/tutorial11-normals/README.md
@@ -594,7 +594,7 @@ where
 I found a cobblestone texture with a matching normal map and created a `debug_material` for that.
 
 ```rust
-// main.rs
+// lib.rs
 impl State {
     async fn new(window: &Window) -> Result<Self> {
         // ...

--- a/docs/intermediate/tutorial12-camera/README.md
+++ b/docs/intermediate/tutorial12-camera/README.md
@@ -10,7 +10,7 @@ Once 0.13 comes out I'll port the WGSL code to the new syntax and this example s
 
 I've been putting this off for a while. Implementing a camera isn't specifically related to using WGPU properly, but it's been bugging me so let's do it.
 
-`main.rs` is getting a little crowded, so let's create a `camera.rs` file to put our camera code. The first things we're going to put in it are some imports and our `OPENGL_TO_WGPU_MATRIX`.
+`lib.rs` is getting a little crowded, so let's create a `camera.rs` file to put our camera code. The first things we're going to put in it are some imports and our `OPENGL_TO_WGPU_MATRIX`.
 
 ```rust
 use cgmath::*;
@@ -254,9 +254,9 @@ impl CameraController {
 }
 ```
 
-## Cleaning up `main.rs`
+## Cleaning up `lib.rs`
 
-First things first we need to delete `Camera` and `CameraController` as well as the extra `OPENGL_TO_WGPU_MATRIX` from `main.rs`. Once you've done that import `camera.rs`.
+First things first we need to delete `Camera` and `CameraController` as well as the extra `OPENGL_TO_WGPU_MATRIX` from `lib.rs`. Once you've done that import `camera.rs`.
 
 ```rust
 mod model;


### PR DESCRIPTION
The beginner tutorials sets everything up in `lib.rs` rather than `main.rs`. This is just a little change to bring the intermediate tutorials in line with what the beginner tutorials set up.