### PR TITLE
added wasm-bindgen-futures dependency to tutorial 1 to match code exa…

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -112,6 +112,7 @@ console_error_panic_hook = "0.1.6"
 console_log = "0.2.0"
 wgpu = { version = "0.12", features = ["webgl"]}
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4.30"
 web-sys = { version = "0.3", features = [
     "Document",
     "Window",


### PR DESCRIPTION
…mple. wasm-pack won't build without it

I completed the tutorial and the final code threw an error. It ended up just needing one more dependency that is included in /code/beginner/tutorial1-window/Cargo.toml