### PR TITLE
Fix some code for Dependencies and the window

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -146,8 +146,8 @@ Next, we need to tell wasm-bindgen to run our `run()` function when the WASM is 
 
 ```rust
 #[cfg_attr(target_arch="wasm32", wasm_bindgen(start))]
-pub async fn run() {
-    // snipped...
+pub fn run() {
+    // same as above for now...
 }
 ```
 


### PR DESCRIPTION
Needed this to get things rendering for me! otherwise we get:
```
$ cargo run
   Compiling rustp v0.1.0 (/Users/jack/dev/rustp)
warning: unused implementer of `Future` that must be used
 --> src/main.rs:4:5
  |
4 |     run();
  |     ^^^^^^
  |
  = note: `#[warn(unused_must_use)]` on by default
  = note: futures do nothing unless you `.await` or poll them

warning: `rustp` (bin "rustp") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.48s
     Running `target/debug/rustp`
```