### PR TITLE
Use 0.13's Surface::get_supported_formats

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -83,7 +83,7 @@ let adapter = instance
     .enumerate_adapters(wgpu::Backends::all())
     .filter(|adapter| {
         // Check if this adapter supports our surface
-        surface.get_preferred_format(&adapter).is_some()
+        surface.get_supported_formats(&adapter).len() > 0
     })
     .next()
     .unwrap()


### PR DESCRIPTION
get_preferred_format no longer exists as per https://docs.rs/wgpu/0.13.1/wgpu/struct.Surface.html#method.get_supported_formats