### PR TITLE
Add `locales` for i18n support.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,11 +1,20 @@
 module.exports = {
     base: '/learn-wgpu/',
-    title: 'Learn Wgpu',
     theme: 'thindark',
     plugins: {
         'vuepress-plugin-code-copy': true,
         '@vuepress/back-to-top': true,
         'seo': {
+        },
+    },
+    locales: {
+        '/': {
+            lang: 'English',
+            title: 'Learn Wgpu',
+        },
+        'https://jinleili.github.io/learn-wgpu-zh/': {
+            lang: '中文',
+            title: '学习 Wgpu',
         },
     },
     themeConfig: {

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,10 +18,6 @@ I'm using this project to learn wgpu myself, so I might miss some important deta
 * Due to wgpu's rapidly changing api, I'm not accepting any new pull requests for showcase demos.
 * If you want to support me directly, check out my [patreon](https://www.patreon.com/sotrh)!
 
-## Translations
-
-* [中文版](https://doodlewind.github.io/learn-wgpu-cn)
-
 ## Special thanks to these patrons!
 
 - David Laban


### PR DESCRIPTION
Modified config.js to add [i18n support](https://v0.vuepress.vuejs.org/guide/i18n.html), and configured a more complete Chinese version of my translation: https://jinleili.github.io/learn-wgpu-zh/

The [previously linked Chinese translation](https://doodlewind.github.io/learn-wgpu-cn) is very incomplete and has not been updated for over six months.

If you feel this PR is unnecessary, no matter, please just close it.