### PR TITLE
fix: Missing struct field

### DIFF
--- a/docs/beginner/tutorial8-depth/README.md
+++ b/docs/beginner/tutorial8-depth/README.md
@@ -117,9 +117,20 @@ pub enum CompareFunction {
 Don't forget to store the `depth_texture` in `State`.
 
 ```rust
-Self {
-// ...
-depth_texture,
+struct State {
+    // ...
+    depth_texture: Texture,
+    // ...
+}
+
+async fn new(window: &Window) -> Self {
+    // ...
+    
+    Self {
+        // ...
+        depth_texture,
+        // ...
+    }
 }
 ```
 


### PR DESCRIPTION
There was no instruction on the field to add to State.

It can be easily found, but it's better if in the tutorial