### PR TITLE
Stop using illegal negative values for `wgpu::SamplerDescriptor::lod_min_clamp`.

### DIFF
--- a/code/beginner/tutorial8-depth/src/texture.rs
+++ b/code/beginner/tutorial8-depth/src/texture.rs
@@ -41,7 +41,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/code/beginner/tutorial9-models/src/texture.rs
+++ b/code/beginner/tutorial9-models/src/texture.rs
@@ -40,7 +40,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/code/intermediate/tutorial10-lighting/src/texture.rs
+++ b/code/intermediate/tutorial10-lighting/src/texture.rs
@@ -40,7 +40,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/code/intermediate/tutorial11-normals/src/texture.rs
+++ b/code/intermediate/tutorial11-normals/src/texture.rs
@@ -40,7 +40,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/code/intermediate/tutorial12-camera/src/texture.rs
+++ b/code/intermediate/tutorial12-camera/src/texture.rs
@@ -40,7 +40,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/code/intermediate/tutorial13-terrain/src/texture.rs
+++ b/code/intermediate/tutorial13-terrain/src/texture.rs
@@ -40,7 +40,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/code/showcase/compute/src/texture.rs
+++ b/code/showcase/compute/src/texture.rs
@@ -54,7 +54,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/code/showcase/framework/src/texture.rs
+++ b/code/showcase/framework/src/texture.rs
@@ -38,7 +38,7 @@ impl<'a> Texture<'a> {
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Nearest,
             mipmap_filter: wgpu::FilterMode::Nearest,
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: Some(wgpu::CompareFunction::LessEqual),
             ..Default::default()
@@ -117,7 +117,7 @@ impl<'a> Texture<'a> {
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Nearest,
             mipmap_filter: wgpu::FilterMode::Nearest,
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: Some(wgpu::CompareFunction::Always),
             ..Default::default()

--- a/code/showcase/mouse-picking/src/texture.rs
+++ b/code/showcase/mouse-picking/src/texture.rs
@@ -40,7 +40,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/code/showcase/threading/src/texture.rs
+++ b/code/showcase/threading/src/texture.rs
@@ -40,7 +40,7 @@ impl Texture {
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             compare: Some(wgpu::CompareFunction::LessEqual),
-            lod_min_clamp: -100.0,
+            lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             ..Default::default()
         });

--- a/docs/beginner/tutorial8-depth/README.md
+++ b/docs/beginner/tutorial8-depth/README.md
@@ -54,7 +54,7 @@ impl Texture {
                 min_filter: wgpu::FilterMode::Linear,
                 mipmap_filter: wgpu::FilterMode::Nearest,
                 compare: Some(wgpu::CompareFunction::LessEqual), // 5.
-                lod_min_clamp: -100.0,
+                lod_min_clamp: 0.0,
                 lod_max_clamp: 100.0,
                 ..Default::default()
             }


### PR DESCRIPTION
Negative values like `-100.0` are illegal for `GPUSamplerDescriptor.lodMinClamp`.

More specifically, WebGPU valid usage states that `lodMinClamp` must not be negative, and `lodMaxClamp` must be >= `lodMinClamp`:
> descriptor.[lodMinClamp](https://gpuweb.github.io/gpuweb/#dom-gpusamplerdescriptor-lodminclamp) ≥ 0.
> descriptor.[lodMaxClamp](https://gpuweb.github.io/gpuweb/#dom-gpusamplerdescriptor-lodmaxclamp) ≥ descriptor.[lodMinClamp](https://gpuweb.github.io/gpuweb/#dom-gpusamplerdescriptor-lodminclamp).

Indeed, Chrome's WebGPU implementation complains:
```console
LOD clamp bounds [-100.000000, 100.000000] contain contain a negative number.
 - While validating [SamplerDescriptor]
 - While calling [Device].CreateSampler([SamplerDescriptor]).
```
It dislikes it even more when we actually try to sample using this illegal sampler:
```console
[Invalid Sampler] is invalid.
 - While validating entries[1] as a Sampler.
Expected entry layout: { binding: 1, visibility: ShaderStage::Fragment, sampler: { type: SamplerBindingType::Filtering } }
 - While validating [BindGroupDescriptor "material_bind_group"] against [BindGroupLayout "material_bind_group_layout"]
 - While calling [Device].CreateBindGroup([BindGroupDescriptor "material_bind_group"]).
```
```console
[Invalid BindGroup "material_bind_group"] is invalid.
 - While encoding [RenderPassEncoder "Render Pass"].SetBindGroup(1, [BindGroup], 0, ...).
```
```console
[Invalid CommandBuffer] is invalid.
    at ValidateObject (..\..\third_party\dawn\src\dawn\native\Device.cpp:651)
    at ValidateSubmit (..\..\third_party\dawn\src\dawn\native\Queue.cpp:393)
```

This PR changes all the illegal negative values to `0.0`.

The value of `0.0` is the default value for ``wgpu::SamplerDescriptor::lod_min_clamp` anyway so technically it can be omitted,
but I think being explicit here helps for documentation purposes.
