### PR TITLE
Removing & reference from new() parameter

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -207,7 +207,7 @@ Regardless, `PresentMode::Fifo` will always be supported, and `PresentMode::Auto
 Now that we've configured our surface properly we can add these new fields at the end of the method.
 
 ```rust
-    async fn new(window: &Window) -> Self {
+    async fn new(window: Window) -> Self {
         // ...
 
         Self {


### PR DESCRIPTION
There is an & reference on the window parameter in one of the example code snippets which seems to be there by mistake. This PR removes it.