### PR TITLE
Remove erroneous code from future

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -300,7 +300,7 @@ We call this method in `run()` in the event loop for the following events.
 match event {
     // ...
 
-    } if window_id == state.window().id() => if !state.input(event) {
+    } if window_id == state.window().id() => {
         match event {
             // ...
 


### PR DESCRIPTION
There is this point in the tutorial where we have just implemented `State::resize`, but then the example code shows a call to `State::input` which has not yet been implemented and won't be until the next section