### PR TITLE
Added missing fields to RenderPassDescriptor

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -427,6 +427,8 @@ Now we can get to clearing the screen (long time coming). We need to use the `en
                 },
             })],
             depth_stencil_attachment: None,
+            occlusion_query_set: None,
+            timestamp_writes: None,
         });
     }
 


### PR DESCRIPTION
WGPU 0.18 made the `occlusion_query_set` and `timestamp_writes` fields mandatory in `RenderPassColorAttachment`. This was fixed in the code for the tutorials but not in the actual tutorial. This PR fixes that.