### PR TITLE
Correct outdated line of example code in surface tutorial

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -162,7 +162,7 @@ The `limits` field describes the limit of certain types of resources that we can
         // sRGB surfaces, you'll need to account for that when drawing to the frame.
         let surface_format = surface_caps.formats.iter()
             .copied()
-            .filter(|f| f.describe().srgb)
+            .filter(|f| f.is_srgb())
             .next()
             .unwrap_or(surface_caps.formats[0]);
         let config = wgpu::SurfaceConfiguration {


### PR DESCRIPTION
Came across this as I was following the tutorial. It seems like this line is no longer correct for the current version of `wgpu`.

Hope this is helpful, and thanks for this excellent resource on wgpu!