### PR TITLE
fix #533 by updating winit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4648,9 +4648,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winit"
-version = "0.28.6"
+version = "0.28.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866db3f712fffba75d31bf0cdecf357c8aeafd158c5b7ab51dba2a2b2d47f196"
+checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
 dependencies = [
  "android-activity",
  "bitflags 1.3.2",


### PR DESCRIPTION
Apparently winit-0.28.7 resolves a problem where an invalid resize request would happen on macOS Sonoma. This resolves issue #533 

See here for details: https://github.com/rust-windowing/winit/issues/2876