### PR TITLE
Avoid using unimplemented input method

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -327,21 +327,19 @@ We call this method `run()` in the event loop for the following events.
 ```rust
 match event {
     // ...
+    } if window_id == state.window().id() => match event {
+        // ...
 
-    } if window_id == state.window().id() => if !state.input(event) {
-        match event {
-            // ...
-
-            WindowEvent::Resized(physical_size) => {
-                state.resize(*physical_size);
-            }
-            WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                // new_inner_size is &&mut so we have to dereference it twice
-                state.resize(**new_inner_size);
-            }
-            // ...
+        WindowEvent::Resized(physical_size) => {
+            state.resize(*physical_size);
         }
+        WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
+            // new_inner_size is &&mut so we have to dereference it twice
+            state.resize(**new_inner_size);
+        }
+        // ...
     }
+    // ...
 }
 ```
 


### PR DESCRIPTION
Thanks for the excellent tutorial on wgpu!

While going through the tutorial, I noticed that the unimplemented `input` method is called in the sample code after the explanation of the resize method. This leads to a compilation error.

So, I have corrected the sample code to fix the error in the resize section.

Hope this is helpful!