### PR TITLE
fix DeviceDescriptor creation

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -135,6 +135,7 @@ Let's use the `adapter` to create the device and queue.
                     wgpu::Limits::default()
                 },
                 label: None,
+                memory_hints: Default::default(),
             },
             None, // Trace path
         ).await.unwrap();


### PR DESCRIPTION
The DeviceDescriptor creation for wgpu 22.0 is missing a field.
This was correctly set in the code but not in the Markdown doc.

(thank you for this awesome tutorial !)