### PR TITLE
fix missing field `window`

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -215,12 +215,12 @@ Now that we've configured our surface properly, we can add these new fields at t
         // ...
 
         Self {
-            window,
             surface,
             device,
             queue,
             config,
             size,
+            window,
         }
     }
 ```

--- a/docs/beginner/tutorial3-pipeline/README.md
+++ b/docs/beginner/tutorial3-pipeline/README.md
@@ -167,6 +167,7 @@ struct State<'a> {
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
     size: winit::dpi::PhysicalSize<u32>,
+    window: &'a Window,
     // NEW!
     render_pipeline: wgpu::RenderPipeline,
 }
@@ -288,6 +289,7 @@ Self {
     queue,
     config,
     size,
+    window,
     // NEW!
     render_pipeline,
 }

--- a/docs/beginner/tutorial4-buffer/README.md
+++ b/docs/beginner/tutorial4-buffer/README.md
@@ -110,6 +110,7 @@ Self {
     queue,
     config,
     size,
+    window,
     render_pipeline,
     vertex_buffer,
 }
@@ -261,6 +262,8 @@ impl<'a> State<'a> {
             device,
             queue,
             config,
+            size,
+            window,
             render_pipeline,
             vertex_buffer,
             num_vertices,
@@ -389,6 +392,7 @@ struct State<'a> {
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
     size: winit::dpi::PhysicalSize<u32>,
+    window: &'a Window,
     render_pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     // NEW!
@@ -406,6 +410,7 @@ Self {
     queue,
     config,
     size,
+    window,
     render_pipeline,
     vertex_buffer,
     // NEW!

--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -49,12 +49,12 @@ Now, let's create the `Texture`:
 let texture_size = wgpu::Extent3d {
     width: dimensions.0,
     height: dimensions.1,
+    // All textures are stored as 3D, we represent our 2D texture
+    // by setting depth to 1.
     depth_or_array_layers: 1,
 };
 let diffuse_texture = device.create_texture(
     &wgpu::TextureDescriptor {
-        // All textures are stored as 3D, we represent our 2D texture
-        // by setting depth to 1.
         size: texture_size,
         mip_level_count: 1, // We'll talk about this a little later
         sample_count: 1,
@@ -248,6 +248,7 @@ struct State<'a> {
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
     size: winit::dpi::PhysicalSize<u32>,
+    window: &'a wgpu::Window,
     render_pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     index_buffer: wgpu::Buffer,
@@ -268,6 +269,7 @@ impl<'a> State<'a> {
             queue,
             config,
             size,
+            window,
             render_pipeline,
             vertex_buffer,
             index_buffer,
@@ -534,7 +536,7 @@ impl Texture {
                 ..Default::default()
             }
         );
-        
+
         Ok(Self { texture, view, sampler })
     }
 }


### PR DESCRIPTION
The window field was introduced in tutorial 1 but was not mentioned in the subsequent tutorials. As I'm still a beginner, please feel free to correct me if I've misunderstood anything.