### PR TITLE
Fix Typo in Tutorial5 Textures

### DIFF
--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -566,7 +566,17 @@ mod texture;
 The texture creation code in `new()` now gets a lot simpler:
 
 ```rust
-surface.configure(&device, &config);
+let config = wgpu::SurfaceConfiguration {
+    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+    format: surface_format,
+    width: size.width,
+    height: size.height,
+    present_mode: surface_caps.present_modes[0],
+    alpha_mode: surface_caps.alpha_modes[0],
+    view_formats: vec![],
+    desired_maximum_frame_latency: 2,
+};
+
 let diffuse_bytes = include_bytes!("happy-tree.png"); // CHANGED!
 let diffuse_texture = texture::Texture::from_bytes(&device, &queue, diffuse_bytes, "happy-tree.png").unwrap(); // CHANGED!
 

--- a/docs/beginner/tutorial5-textures/README.md
+++ b/docs/beginner/tutorial5-textures/README.md
@@ -27,10 +27,19 @@ Decoding jpegs in WASM isn't very performant. If you want to speed up image load
 
 </div>
 
-In `State`'s `new()` method, add the following just after configuring the `surface`:
+In `State`'s `new()` method, add the following just after declaring the `config`:
 
 ```rust
-surface.configure(&device, &config);
+let config = wgpu::SurfaceConfiguration {
+    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+    format: surface_format,
+    width: size.width,
+    height: size.height,
+    present_mode: surface_caps.present_modes[0],
+    alpha_mode: surface_caps.alpha_modes[0],
+    view_formats: vec![],
+    desired_maximum_frame_latency: 2,
+};
 // NEW!
 
 let diffuse_bytes = include_bytes!("happy-tree.png");


### PR DESCRIPTION
The position suggested to insert new code in the doc doesn't exit in the demo, I replace it so learners can better locate where to add new code. 