### PR TITLE
Fix missing variables and remove inaccurate comment

### DIFF
--- a/code/beginner/tutorial2-surface/src/lib.rs
+++ b/code/beginner/tutorial2-surface/src/lib.rs
@@ -16,9 +16,6 @@ struct State<'a> {
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
     size: winit::dpi::PhysicalSize<u32>,
-    // The window must be declared after the surface so
-    // it gets dropped after it as the surface contains
-    // unsafe references to the window's resources.
     window: &'a Window,
 }
 

--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -232,6 +232,7 @@ pub async fn run() {
     // Window setup...
 
     let mut state = State::new(&window).await;
+    let mut surface_configured = false;
 
     event_loop.run(move |event, control_flow| {
         match event {
@@ -330,6 +331,7 @@ match event {
         match event {
             // ...
             WindowEvent::Resized(physical_size) => {
+                surface_configured = true;
                 state.resize(*physical_size);
             }
             // ...
@@ -373,6 +375,7 @@ event_loop.run(move |event, control_flow| {
                     ..
                 } => control_flow.exit(),
                 WindowEvent::Resized(physical_size) => {
+                    surface_configured = true;
                     state.resize(*physical_size);
                 }
                 _ => {}


### PR DESCRIPTION
Align tutorial2 docs with tutorial2 code.
```surface_configured``` is never initialised before it is used in docs.

Remove a comment from tutorial2 code to align with a change made to the tutorial2 docs here 15f0909372c7799f44f7d7aca1b2e6260848b7d4