### PR TITLE
beginner/tutorial2-surface: fix duplicate struct field assignment

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -195,7 +195,6 @@ Now that we've configured our surface properly, we can add these new fields at t
             queue,
             config,
             is_surface_configured: false,
-            is_surface_configured: false,
             window,
         })
     }


### PR DESCRIPTION
Thank you for the great tutorial, while reading along I noticed that `is_surface_configured` is assigned to twice in the struct literal, which will be an error for anyone copy-pasting this code.