### PR TITLE
Fix missing call to `update()` in tutorial 2

### DIFF
--- a/code/beginner/tutorial2-surface/src/lib.rs
+++ b/code/beginner/tutorial2-surface/src/lib.rs
@@ -105,7 +105,7 @@ impl State {
 
     fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
         self.window.request_redraw();
-        
+
         // We can't render unless the surface is configured
         if !self.is_surface_configured {
             return Ok(());
@@ -149,7 +149,7 @@ impl State {
 
         Ok(())
     }
-    
+
     fn handle_key(&mut self, event_loop: &ActiveEventLoop, code: KeyCode, is_pressed: bool) {
         match (code, is_pressed) {
             (KeyCode::Escape, true) => event_loop.exit(),
@@ -248,6 +248,7 @@ impl ApplicationHandler<State> for App {
             WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::Resized(size) => state.resize(size.width, size.height),
             WindowEvent::RedrawRequested => {
+                state.update();
                 match state.render() {
                     Ok(_) => {}
                     // Reconfigure the surface if it's lost or outdated

--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -367,6 +367,7 @@ We need to update the event loop again to call this method. We'll also call `upd
         match event {
             // ...
             WindowEvent::RedrawRequested => {
+                state.update();
                 match state.render() {
                     Ok(_) => {}
                     // Reconfigure the surface if it's lost or outdated


### PR DESCRIPTION
The docs mention

> We'll also call update() before it, too

but this call seems to be missing. This PR fixes that 😄 