### PR TITLE
In tutorial 1, use key_state instead of shadowed state - as similar to tutorial 2

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -211,11 +211,11 @@ impl ApplicationHandler<State> for App {
                 event:
                     KeyEvent {
                         physical_key: PhysicalKey::Code(code),
-                        state,
+                        state: key_state,
                         ..
                     },
                 ..
-            } => match (code, state.is_pressed()) {
+            } => match (code, key_state.is_pressed()) {
                 (KeyCode::Escape, true) => event_loop.exit(),
                 _ => {}
             },


### PR DESCRIPTION
Shadowing `state` during decomposition of WindowEvent is slightly confusing.
Also, it is more similar to tutorial 2.