### PR TITLE
Use `div_ceil` where appropriate.

### DIFF
--- a/code/compute/src/filter.rs
+++ b/code/compute/src/filter.rs
@@ -59,7 +59,7 @@ pub fn run() -> anyhow::Result<()> {
     let mut encoder = device.create_command_encoder(&Default::default());
 
     {
-        let num_dispatches = input_data.len() as u32 / 64 + (input_data.len() % 64 > 0) as u32;
+        let num_dispatches = input_data.len().div_ceil(64) as u32;
 
         let mut pass = encoder.begin_compute_pass(&Default::default());
         pass.set_pipeline(&pipeline);

--- a/code/compute/src/introduction.rs
+++ b/code/compute/src/introduction.rs
@@ -62,7 +62,7 @@ pub async fn run() -> anyhow::Result<()> {
     {
         // We specified 64 threads per workgroup in the shader, so we need to compute how many
         // workgroups we need to dispatch.
-        let num_dispatches = input_data.len() as u32 / 64 + (input_data.len() % 64 > 0) as u32;
+        let num_dispatches = input_data.len().div_ceil(64) as u32;
 
         let mut pass = encoder.begin_compute_pass(&Default::default());
         pass.set_pipeline(&pipeline);

--- a/code/compute/src/sort.rs
+++ b/code/compute/src/sort.rs
@@ -48,7 +48,7 @@ pub async fn run() -> anyhow::Result<()> {
     let num_dispatches = (input_data.len() / num_items_per_workgroup) as u32
         + (input_data.len() % num_items_per_workgroup > 0) as u32;
     // We do 2 passes in the shader so we only need to do half the passes
-    let num_passes = input_data.len() / 2 + input_data.len() % 2;
+    let num_passes = input_data.len().div_ceil(2);
 
     {
         let mut pass = encoder.begin_compute_pass(&Default::default());

--- a/code/showcase/snow/src/main.rs
+++ b/code/showcase/snow/src/main.rs
@@ -332,7 +332,7 @@ impl framework::Demo for Snow {
         move_pass.set_pipeline(&self.move_particles);
         move_pass.set_bind_group(0, &self.particle_bind_groups[self.iteration % 2], &[]);
 
-        let num_workgroups = self.num_particles / 64 + (self.num_particles % 64 != 0) as u32;
+        let num_workgroups = self.num_particles.div_ceil(64) as u32;
         move_pass.dispatch_workgroups(num_workgroups, 1, 1);
 
         drop(move_pass);

--- a/docs/compute/introduction/readme.md
+++ b/docs/compute/introduction/readme.md
@@ -233,7 +233,7 @@ of what's called the "compute shader grid". Consider this code.
     {
         // We specified 64 threads per workgroup in the shader, so we need to compute how many
         // workgroups we need to dispatch.
-        let num_dispatches = input_data.len() as u32 / 64 + (input_data.len() % 64 > 0) as u32;
+        let num_dispatches = input_data.len().div_ceil(64) as u32;
 
         let mut pass = encoder.begin_compute_pass(&Default::default());
         pass.set_pipeline(&pipeline);

--- a/docs/compute/sorting/readme.md
+++ b/docs/compute/sorting/readme.md
@@ -233,7 +233,7 @@ code to call the shader:
     let num_dispatches = (input_data.len() / num_items_per_workgroup) as u32
         + (input_data.len() % num_items_per_workgroup > 0) as u32;
     // We do 2 passes in the shader so we only need to do half the passes
-    let num_passes = input_data.len() / 2 + input_data.len() % 2;
+    let num_passes = input_data.len().div_ceil(2);
 
     {
         let mut pass = encoder.begin_compute_pass(&Default::default());


### PR DESCRIPTION
Several places in the tutorial need to do a division that rounds up, for chunking operations. They use a form like `n / k + (n % k > 0)`.

I'm used to seeing this kind of division done with `(n + (k - 1)) / k`. This is probably preferred because it avoids the `%` operation, which is typically expensive.

But Rust has a builtin for this: `div_ceil`. Even better.