### PR TITLE
A sorted list must be non-decreasing, not necessarily strictly increasing

### DIFF
--- a/code/compute/src/sort.rs
+++ b/code/compute/src/sort.rs
@@ -77,7 +77,7 @@ pub async fn run() -> anyhow::Result<()> {
         // Confirm that the list is sorted
         for i in 1..u32_data.len() {
             assert!(
-                u32_data[i] > u32_data[i - 1],
+                u32_data[i] >= u32_data[i - 1],
                 "{}, {}",
                 u32_data[i - 1],
                 u32_data[i]


### PR DESCRIPTION
n.b. there is still a bug in this sort and it sometimes returns out of order elements; however, it doesn't crash spuriously on identical elements anymore.

If I change the code from an assert to:
```rust
        // Confirm that the list is sorted
        println!("Confirming {} items sorted:", u32_data.len());
        for i in 1..u32_data.len() {
            println!("{} <= {}? {}", u32_data[i - 1], u32_data[i], u32_data[i - 1] <= u32_data[i]);
            /*
            assert!(
                u32_data[i] >= u32_data[i - 1],
                "{}, {}",
                u32_data[i - 1],
                u32_data[i]
            );
            */
        }
```

then I see occasional out of order elements...