### PR TITLE
add `vue-template-compiler` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "ISC",
   "devDependencies": {
     "@vuepress/plugin-back-to-top": "^1.9.5",
+    "vue-template-compiler": "^2.7.16",
     "vuepress": "^1.9.5",
     "vuepress-plugin-code-copy": "^1.0.6",
     "vuepress-plugin-seo": "^0.2.0",


### PR DESCRIPTION
It seems that the `run dev` command depends on the `vue-template-compiler`. 

```
$ pnpm run dev

> learn-wgpu@1.0.0 dev /Volumes/Dev/github/learn-wgpu
> cross-env NODE_OPTIONS=--openssl-legacy-provider; ./build-wasm.sh && vuepress dev docs

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/wasm-builder wasm-targets.json`
warning: output filename collision at /Volumes/Dev/github/learn-wgpu/target/wasm32-unknown-unknown/release/compute.wasm
  |
  = note: the bin target `compute` in package `compute v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/compute)` has the same output filename as the lib target `compute` in package `compute v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/compute)`
  = note: this may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>
  = help: consider changing their names to be unique or compiling them separately
warning: output filename collision at /Volumes/Dev/github/learn-wgpu/target/wasm32-unknown-unknown/release/compute.wasm.dwp
  |
  = note: the bin target `compute` in package `compute v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/compute)` has the same output filename as the lib target `compute` in package `compute v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/compute)`
  = note: this may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>
  = help: consider changing their names to be unique or compiling them separately
   Compiling tutorial9-models v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/beginner/tutorial9-models)
   Compiling tutorial10-lighting v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/intermediate/tutorial10-lighting)
   Compiling tutorial12-camera v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/intermediate/tutorial12-camera)
   Compiling tutorial11-normals v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/intermediate/tutorial11-normals)
   Compiling tutorial13-hdr v0.1.0 (/Volumes/Dev/github/learn-wgpu/code/intermediate/tutorial13-hdr)
    Finished `release` profile [optimized] target(s) in 4.76s
wait Extracting site metadata...
tip Apply theme vuepress-theme-thindark ...
tip Apply plugin container (i.e. "vuepress-plugin-container") ...
tip Apply plugin @vuepress/last-updated (i.e. "@vuepress/plugin-last-updated") ...
tip Apply plugin @vuepress/register-components (i.e. "@vuepress/plugin-register-components") ...
tip Apply plugin @vuepress/active-header-links (i.e. "@vuepress/plugin-active-header-links") ...
tip Apply plugin @vuepress/search (i.e. "@vuepress/plugin-search") ...
tip Apply plugin @vuepress/nprogress (i.e. "@vuepress/plugin-nprogress") ...
tip Apply plugin code-copy (i.e. "vuepress-plugin-code-copy") ...
tip Apply plugin @vuepress/back-to-top (i.e. "@vuepress/plugin-back-to-top") ...
tip Apply plugin seo (i.e. "vuepress-plugin-seo") ...
(node:31346) [DEP0187] DeprecationWarning: Passing invalid argument types to fs.existsSync is deprecated
(Use `node --trace-deprecation ...` to show where the warning was created)
Error: Cannot find module 'vue-template-compiler'
Require stack:
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/compiler.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/resolveScript.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/select.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/index.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/@vuepress+core@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/@vuepress/core/lib/node/webpack/createBaseConfig.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/@vuepress+core@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/@vuepress/core/lib/node/webpack/createClientConfig.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/@vuepress+core@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/@vuepress/core/lib/node/dev/index.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/@vuepress+core@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/@vuepress/core/lib/node/App.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/@vuepress+core@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/@vuepress/core/lib/index.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vuepress@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/vuepress/lib/registerCoreCommands.js
- /Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vuepress@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/vuepress/cli.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1420:15)
    at require.resolve (node:internal/modules/helpers:163:19)
    at loadFromContext (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/compiler.js:30:26)
    at loadTemplateCompiler (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/compiler.js:37:12)
    at exports.resolveCompiler (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/compiler.js:25:23)
    at VueLoaderPlugin.apply (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/plugin-webpack4.js:91:22)
    at VueLoaderPlugin.apply (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/vue-loader@15.11.1_@vue+compiler-sfc@3.5.26_cache-loader@3.0.1_webpack@4.47.0__css-load_b72aae6f2ffa6d2b27f9f70aa32626d8/node_modules/vue-loader/lib/plugin.js:13:16)
    at webpack (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/webpack@4.47.0/node_modules/webpack/lib/webpack.js:51:13)
    at DevProcess.createServer (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/@vuepress+core@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/@vuepress/core/lib/node/dev/index.js:241:22)
    at error (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/@vuepress+core@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/@vuepress/core/lib/node/App.js:477:14)
    at new Promise (<anonymous>)
    at App.dev (/Volumes/Dev/github/learn-wgpu/node_modules/.pnpm/@vuepress+core@1.9.10_@vue+compiler-sfc@3.5.26_hogan.js@3.0.2_lodash@4.17.21/node_modules/@vuepress/core/lib/node/App.js:470:25)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
^C ELIFECYCLE  Command failed.
```