### PR TITLE
Typo fix: missing space in tutorial one

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -102,7 +102,7 @@ impl App {
 
 So the `App` struct has two fields: `state` and `proxy`.
 
-The `state` variable stores our `State` struct as an option.The reason we need an option is that `State::new()` needs a window and we can't create a window until the application gets to the `Resumed` state. We'll get more into that in a bit.
+The `state` variable stores our `State` struct as an option. The reason we need an option is that `State::new()` needs a window and we can't create a window until the application gets to the `Resumed` state. We'll get more into that in a bit.
 
 The `proxy` variable is only needed on the web. The reason for this is that creating WGPU resources is an async process. Again we'll get into that in a bit.
 


### PR DESCRIPTION
Minor typo for a missing space.

Main goal is to get familiarized with contributing to this project. I didn't find any specific instructions so let me know if any additional structure is expected/helpful