### PR TITLE
Fix compiler error related to App::new instantiation

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -14,7 +14,7 @@ anyhow = "1.0"
 winit = { version = "0.30", features = ["android-native-activity"] }
 env_logger = "0.10"
 log = "0.4"
-wgpu = "28.0"
+wgpu = "29.0.3"
 pollster = "0.3"
 ```
 

--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -245,7 +245,7 @@ pub fn run() -> anyhow::Result<()> {
     let event_loop = EventLoop::with_user_event().build()?;
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let mut app = App::new();
+        let mut app = App::new(&event_loop);
         event_loop.run_app(&mut app)?;
     }
     #[cfg(target_arch = "wasm32")]

--- a/docs/beginner/tutorial8-depth/README.md
+++ b/docs/beginner/tutorial8-depth/README.md
@@ -120,7 +120,7 @@ Don't forget to store the `depth_texture` in `State`.
 ```rust
 pub struct State {
     // ...
-    depth_texture: Texture,
+    depth_texture: texture::Texture,
     // ...
 }
 


### PR DESCRIPTION
at least on native implementation, the user must pass &event to the app instantiation in order to get a window working. 

Unsure if this effects web targets. 

First time using following this tutorial and noticed I had to let new borrow &event_loop in order to get rid of compiler error and finally open a window.