### PR TITLE
Update tutorial 1 to wgpu 30.0

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -14,7 +14,7 @@ anyhow = "1.0"
 winit = { version = "0.30", features = ["android-native-activity"] }
 env_logger = "0.10"
 log = "0.4"
-wgpu = "28.0"
+wgpu = "30.0"
 pollster = "0.3"
 ```
 
@@ -297,7 +297,7 @@ strip = true
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
 console_log = "1.0"
-wgpu = { version = "28.0", features = ["webgl"]}
+wgpu = { version = "30.0", features = ["webgl"]}
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.30"
 web-sys = { version = "0.3", features = [


### PR DESCRIPTION
## Summary

- update the native and WASM dependency snippets in tutorial 1 from wgpu 28.0 to 30.0
- keep the documentation aligned with the current tutorial 1 Cargo manifest after the 30.0 migration

Fixes #670

## Verification

- verified both documented versions match the native and WASM manifest entries
- built all 49 VuePress pages
- ran the full Rust workspace test and doctest suite
- ran git diff --check